### PR TITLE
Make it configurable whether a command is being run in a tty or not

### DIFF
--- a/library/twopence.h
+++ b/library/twopence.h
@@ -172,6 +172,10 @@ struct twopence_command {
 	/* The duration in seconds after which we abort the command. Default to 60L */
 	long			timeout;
 
+	/* Execute the command in a tty rather than just connected to a pipe.
+	 * May be needed for some commands to behave properly */
+	bool			request_tty;
+
 	/* FIXME: support passing environment variables to the command --okir
 	 *
          * For the time being we can start "bash" as a command

--- a/python/command.c
+++ b/python/command.c
@@ -195,6 +195,7 @@ Command_build(twopence_Command *self, twopence_command_t *cmd)
 
 	cmd->user = self->user;
 	cmd->timeout = self->timeout;
+	cmd->request_tty = self->useTty;
 
 	twopence_command_ostreams_reset(cmd);
 	if (self->suppressOutput || self->stdout == Py_None) {
@@ -287,6 +288,13 @@ Command_getattr(twopence_Command *self, char *name)
 		return Command_stdout(self);
 	if (!strcmp(name, "stderr"))
 		return Command_stderr(self);
+	if (!strcmp(name, "useTty")) {
+		PyObject *rv;
+
+		rv = self->useTty? Py_True : Py_False;
+		Py_INCREF(rv);
+		return rv;
+	}
 
 	return Py_FindMethod(twopence_commandMethods, (PyObject *) self, name);
 }
@@ -320,6 +328,10 @@ Command_setattr(twopence_Command *self, char *name, PyObject *v)
 		if (!PyString_Check(v) || (s = PyString_AsString(v)) == NULL)
 			goto bad_attr;
 		self->timeout = atol(s);
+		return 0;
+	}
+	if (!strcmp(name, "useTty")) {
+		self->useTty = !!(PyObject_IsTrue(v));
 		return 0;
 	}
 

--- a/python/extension.h
+++ b/python/extension.h
@@ -44,6 +44,7 @@ typedef struct {
 	int		suppressOutput;
 	PyObject *	stdout;
 	PyObject *	stderr;
+	bool		useTty;
 } twopence_Command;
 
 typedef struct {


### PR DESCRIPTION
This should hopefully fix the CR-NL issues you were seeing. The use of a pty is now an opt-in thing, and currently exposed to the python binding only. If we want to expose it in the shell utils, we need to convert them to use struct twopence_command first.

Olaf

Signed-off-by: Olaf Kirch <okir@suse.de>