### PR TITLE
Fix "make tests" target

### DIFF
--- a/tests/ruby_test.sh
+++ b/tests/ruby_test.sh
@@ -20,6 +20,12 @@ if [ -z "$TARGET" ]; then
 EOF
 fi
 
+rspec=`type -p rspec`
+if [ $? -ne 0 -o -z "$rspec" ]; then
+  echo "rspec command not found; skipping ruby tests"
+  exit 0
+fi
+
 # we can't pass command line arguments to rspec
 # but we can use $TARGET environment variable
 rspec spec/ruby_test.rb

--- a/tests/run-virtio
+++ b/tests/run-virtio
@@ -3,6 +3,9 @@
 # Run a test script against a virtio target.
 #
 
+myname=`readlink -f $0`
+TOPDIR=${myname%/tests/*}
+
 SCRIPT=$1; shift
 if [ -z "$SCRIPT" ]; then
 	echo "$0: you have to specify a test script as argument" >&2
@@ -14,13 +17,32 @@ if [ ! -x "$SCRIPT" ]; then
 	exit 1
 fi
 
+export LD_LIBRARY_PATH=$TOPDIR/library
+export PYTHONPATH=$TOPDIR/python
+
+
 # First, start the test server
-export LD_LIBRARY_PATH=$PWD/library
+cat <<EOF
+------------------------------------------------------------------
+--- Starting test server ---
+
+EOF
 ../server/twopence_test_server --daemon --port-unix /tmp/twopence.sock
 
-export PYTHONPATH=$PWD/python
+cat <<EOF
+------------------------------------------------------------------
+--- Running $SCRIPT virtio:/tmp/twopence.sock ---
+
+EOF
+
 $SCRIPT virtio:/tmp/twopence.sock
 status=$?
+
+cat <<EOF
+
+--- Exit status $status ---
+------------------------------------------------------------------
+EOF
 
 if [ $status -ne 0 ]; then
 	echo "Test script failed (status=$status)" >&2

--- a/tests/shell_test.sh
+++ b/tests/shell_test.sh
@@ -127,8 +127,8 @@ fi
 test_case_report
 
 
-test_case_begin "silent command 'ping -c1 8.8.8.8'"
-twopence_command -q $TARGET 'ping -c1 8.8.8.8'
+test_case_begin "silent command 'ping -c1 127.0.0.1'"
+twopence_command -q $TARGET 'ping -c1 127.0.0.1'
 test_case_check_status $?
 test_case_report
 

--- a/tests/shell_test.sh
+++ b/tests/shell_test.sh
@@ -20,33 +20,37 @@ if [ -z "$TARGET" ]; then
 	EOF
 fi
 
+if [ -z "$TOPDIR" ]; then
+	myname=`readlink -f $0`
+	TOPDIR=${myname%/tests/*}
+fi
+if [ -z "$LD_LIBRARY_PATH" ]; then
+	export LD_LIBRARY_PATH=$TOPDIR/library
+fi
+
 overall_status=0
 
 function twopence_command {
 
 	echo "### ../shell/command $@" >&2
-	export LD_LIBRARY_PATH=$PWD/library
 	../shell/command "$@"
 }
 
 function twopence_command_background {
 
 	echo "### ../shell/command $@" >&2
-	export LD_LIBRARY_PATH=$PWD/library
 	../shell/command "$@" &
 }
 
 function twopence_inject {
 
 	echo "### ../shell/inject $@" >&2
-	export LD_LIBRARY_PATH=$PWD/library
 	../shell/inject "$@"
 }
 
 function twopence_extract {
 
 	echo "### ../shell/extract $@" >&2
-	export LD_LIBRARY_PATH=$PWD/library
 	../shell/extract "$@"
 }
 


### PR DESCRIPTION
Commit 869fb560 moved files around, and introduced a makefile
in tests/. Instead of executing the tests with the top twopence
source directory as current working directory, the tests are
now executed with PWD=$topdir/tests. This caused LD_LIBRARY_PATH
to be set incorrecty, causing all tests to fail if libtwopence
is not in the installed system.

This patch fixes this issue.

Another change introduced by this patch is to silently skip the
ruby tests if rspec is not installed.

Signed-off-by: Olaf Kirch <okir@suse.de>