### PR TITLE
Server tracing

### DIFF
--- a/server/main.c
+++ b/server/main.c
@@ -271,7 +271,7 @@ int main(int argc, char *argv[])
     usage:
 	fprintf(stderr,
 		"Usage:\n"
-		"%s <portspec>\n"
+		"%s [options] <portspec>\n"
 		"Where portspec can be one of the following:\n\n"
 		"no arguments:\n"
 		"    open the default serial port\n"
@@ -284,6 +284,14 @@ int main(int argc, char *argv[])
 		"--port-pty:\n"
 		"    open a pty master, print the pty slave path on stdout, and background the server process\n"
 		"    This is not implemented yet.\n"
+		"\n"
+		"Supported options:\n"
+		"--daemon\n"
+		"    Background the server process and run it as a daemon\n"
+		"--debug, -d\n"
+		"    Increase debugging verbosity\n"
+		"--one-shot\n"
+		"    Service one incoming connection, then exit\n"
 		"\n"
 		"The default serial port is %s\n"
 		, argv[0], TWOPENCE_SERIAL_PORT_DEFAULT);

--- a/server/main.c
+++ b/server/main.c
@@ -57,7 +57,9 @@ static void		service_connection(int);
 static void		server_daemonize(void);
 
 FILE *			server_log_file = NULL;
-unsigned int		server_tracing = 0;
+unsigned int		server_debug_level = 0;
+bool			server_audit = false;
+unsigned int		server_audit_seq;
 
 
 ////////////////////////////////////// Lower layer ///////////////////////////
@@ -209,6 +211,7 @@ int main(int argc, char *argv[])
     { "port-unix", required_argument, NULL, 'U' },
     { "daemon", no_argument, NULL, 'D' },
     { "debug", no_argument, NULL, 'd' },
+    { "audit", no_argument, NULL, 't' },
     { NULL }
   };
   int opt_oneshot = 0;
@@ -230,7 +233,7 @@ int main(int argc, char *argv[])
       break;
 
     case 'd':
-      server_tracing++;
+      server_debug_level++;
       break;
 
     case 'D':
@@ -255,6 +258,10 @@ int main(int argc, char *argv[])
 
       opt_port_type = "pty";
       opt_port_path = optarg;
+      break;
+
+    case 't':
+      server_audit = true;
       break;
 
     case 'U':
@@ -292,6 +299,8 @@ int main(int argc, char *argv[])
 		"    Increase debugging verbosity\n"
 		"--one-shot\n"
 		"    Service one incoming connection, then exit\n"
+		"--audit\n"
+		"    Print an audit trail of operations to the log\n"
 		"\n"
 		"The default serial port is %s\n"
 		, argv[0], TWOPENCE_SERIAL_PORT_DEFAULT);

--- a/server/server.1
+++ b/server/server.1
@@ -102,6 +102,10 @@ This option requests increased debugging information. Specifying this option
 several times increases the verbosity.
 Currently, debug information is always printed to standard error, thus using
 this option together with \fB--daemon\fB is not all that useful.
+.IP "\fB--audit\fP
+This option can be used to request an audit trail of the operations performed
+by the test server. It will log the names of the files transferred, and the 
+commands being executed, along with relevant parameters.
 .\" --------------------------------------------------------------
 .\"
 .\"

--- a/server/server.c
+++ b/server/server.c
@@ -475,6 +475,7 @@ server_inject_file(transaction_t *trans, const char *username, const char *filen
 	int status;
 	int fd;
 
+	AUDIT("inject \"%s\"; user=%s\n", filename, username);
 	if ((fd = server_open_file_as(username, filename, filemode, O_WRONLY|O_CREAT|O_TRUNC, &status)) < 0) {
 		transaction_fail(trans, status);
 		return false;
@@ -542,6 +543,7 @@ server_extract_file(transaction_t *trans, const char *username, const char *file
 	int status;
 	int fd;
 
+	AUDIT("extract \"%s\"; user=%s\n", filename, username);
 	if ((fd = server_open_file_as(username, filename, 0600, O_RDONLY, &status)) < 0) {
 		transaction_fail(trans, status);
 		return false;
@@ -667,6 +669,7 @@ server_run_command(transaction_t *trans, const char *username, unsigned int time
 	int nattached = 0;
 	pid_t pid;
 
+	AUDIT("run \"%s\"; user=%s timeout=%u\n", cmdline, username, timeout);
 	if ((pid = server_run_command_as(username, timeout, cmdline, command_fds, &status)) < 0) {
 		transaction_fail2(trans, status, 0);
 		return false;

--- a/server/server.h
+++ b/server/server.h
@@ -178,13 +178,23 @@ extern void		server_run(socket_t *);
 
 #define __TRACE(level, fmt...) \
 	do { \
-		if (server_tracing >= level) \
+		if (server_debug_level >= level) \
 			twopence_trace(fmt); \
 	} while (0)
 #define TRACE(fmt...)	__TRACE(1, fmt)
 #define TRACE2(fmt...)	__TRACE(2, fmt)
 
-extern unsigned int	server_tracing;
+#define AUDIT(fmt, args...) \
+	do { \
+		if (server_audit) { \
+			twopence_trace("%5u: " fmt, server_audit_seq++, ##args); \
+		} \
+	} while (0)
+
+extern unsigned int	server_debug_level;
+
+extern bool		server_audit;
+extern unsigned int	server_audit_seq;
 
 extern void		twopence_trace(const char *fmt, ...);
 extern void		twopence_log_error(const char *fmt, ...);


### PR DESCRIPTION
Running the server with the --audit option should now give you an audit trail of its operations.
These patches also update the help message and manpage.

Olaf