### PR TITLE
ssh and virtio line timeout fix

### DIFF
--- a/TODO
+++ b/TODO
@@ -15,6 +15,13 @@ BUGS
    o Makefiles:
      "make clean" leaves files behind
 
+   o The ssh "line timeout" is constant at 60 seconds, which means
+     that if you try to run a command that sleeps for longer than
+     60 seconds, the command will be aborted by the client with a
+     TWOPENCE_RECEIVE_RESULTS_ERROR.
+
+     Reproduce:
+       ./run-one ssh ./python_test.sh
 
 REFACTORING
    o in ssh.c, replace

--- a/TODO
+++ b/TODO
@@ -15,13 +15,37 @@ BUGS
    o Makefiles:
      "make clean" leaves files behind
 
-   o The ssh "line timeout" is constant at 60 seconds, which means
+   o The "line timeout" is constant at 60 seconds, which means
      that if you try to run a command that sleeps for longer than
      60 seconds, the command will be aborted by the client with a
      TWOPENCE_RECEIVE_RESULTS_ERROR.
 
      Reproduce:
        ./run-one ssh ./python_test.sh
+       ./run-one virtio ./python_test.sh
+
+   o The protocol used for virtio has no request/reply matching.
+     Problem (we == client):
+      - send command (command1)
+      - we time out locally (due to the link timeout)
+      - we return to the caller
+      - we send the next command (command2)
+      - server sends us the status of command1
+      - we receive this status and think it's the
+        status for command1.
+
+     Proposed fix: we need to use the free byte in the protocol
+     header as transaction id (XID). However, care needs to be
+     taken of the shell command case, where the client always starts
+     with "this is my first transaction", so we cannot just use a
+     client side counter.
+
+     The best approach may be for the client to send the initial
+     request with an XID of 0, and the server assigns an XID and
+     returns that in the first packet, which is the Major status.
+     All subsequent packets related to this transaction (client
+     to server data, server to client data, interrupt, status)
+     should use the assigned XID.
 
 REFACTORING
    o in ssh.c, replace

--- a/TODO
+++ b/TODO
@@ -15,15 +15,6 @@ BUGS
    o Makefiles:
      "make clean" leaves files behind
 
-   o The "line timeout" is constant at 60 seconds, which means
-     that if you try to run a command that sleeps for longer than
-     60 seconds, the command will be aborted by the client with a
-     TWOPENCE_RECEIVE_RESULTS_ERROR.
-
-     Reproduce:
-       ./run-one ssh ./python_test.sh
-       ./run-one virtio ./python_test.sh
-
    o The protocol used for virtio has no request/reply matching.
      Problem (we == client):
       - send command (command1)

--- a/library/protocol.c
+++ b/library/protocol.c
@@ -628,6 +628,16 @@ __twopence_pipe_command
     return TWOPENCE_SEND_COMMAND_ERROR;
   }
 
+  /* This entire line timeout business seems not very useful, at least while
+   * waiting for a command to finish - that command may sleep for minutes
+   * without producing any output.
+   * For now, we make sure that the link timeout is the maximum of LINE_TIMEOUT
+   * and (command timeout + 1).
+   */
+  handle->link_timeout = (timeout + 1) * 1000;
+  if (handle->link_timeout < LINE_TIMEOUT)
+    handle->link_timeout = LINE_TIMEOUT;
+
   // Read "standard output" and "standard error"
   rc = _twopence_read_results(handle, link_fd, status_ret);
   if (rc < 0)

--- a/library/ssh.c
+++ b/library/ssh.c
@@ -37,7 +37,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "twopence.h"
 
 #define BUFFER_SIZE 16384              // Size in bytes of the work buffer for receiving data from the remote host
-#define LINE_TIMEOUT 60                // Timeout (in seconds) for not receiving anything
 
 // This structure encapsulates in an opaque way the behaviour of the library
 // It is not 100 % opaque, because it is publicly known that the first field is the plugin type
@@ -288,12 +287,10 @@ __twopence_ssh_read_results(struct twopence_ssh_target *handle, long timeout, ss
   bool nothing_0, eof_0,
        nothing_1, eof_1,
        nothing_2, eof_2;
-  time_t line_too_late,
-         command_too_late;
+  time_t command_too_late;
 
   eof_0 = eof_1 = eof_2 = false;
-  line_too_late = command_too_late = time(NULL);
-  line_too_late += LINE_TIMEOUT;
+  command_too_late = time(NULL);
   command_too_late += timeout;
 
   // While there might still be something to read from the remote host
@@ -341,14 +338,9 @@ __twopence_ssh_read_results(struct twopence_ssh_target *handle, long timeout, ss
       // Then avoid active wait
       __twopence_ssh_sleep();
 
-      // And check for timeout
-      if (time(NULL) > line_too_late)
-        return -4;
-
-    if (time(NULL) > command_too_late)
-     return -5;
+      if (time(NULL) > command_too_late)
+       return -5;
     }
-    else line_too_late = time(NULL) + LINE_TIMEOUT;
   }
   return 0;
 }

--- a/python/command.c
+++ b/python/command.c
@@ -384,11 +384,12 @@ Command_setattr(twopence_Command *self, char *name, PyObject *v)
 		return 0;
 	}
 	if (!strcmp(name, "timeout")) {
-		char *s;
-
-		if (!PyString_Check(v) || (s = PyString_AsString(v)) == NULL)
+		if (PyInt_Check(v))
+			self->timeout = PyInt_AsLong(v);
+		else if (PyLong_Check(v))
+			self->timeout = PyLong_AsLongLong(v);
+		else
 			goto bad_attr;
-		self->timeout = atol(s);
 		return 0;
 	}
 	if (!strcmp(name, "useTty")) {

--- a/server/server.c
+++ b/server/server.c
@@ -327,6 +327,8 @@ server_path_find_bin(const char *argv0)
 		"/sbin",
 		"/usr/bin",
 		"/usr/sbin",
+		"/usr/local/bin",
+		"/usr/local/sbin",
 		NULL
 	};
 	unsigned int n;

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -156,6 +156,56 @@ except:
 os.remove("etc_hosts")
 testCaseReport()
 
+testCaseBegin("Verify twopence.Command attributes")
+try:
+	outbuf = bytearray();
+	errbuf = bytearray();
+	cmd = twopence.Command("/bin/something", user = "eric",
+				 timeout = 123,
+				 stdin = "/local/file", 
+				 stdout = outbuf,
+				 stderr = errbuf,
+				 suppressOutput = True);
+	print "Verify commandline attribute"
+	if cmd.commandline != "/bin/something":
+		testCaseFail("cmd.commandline attribute invalid")
+	print "Verify user attribute"
+	if cmd.user != "eric":
+		testCaseFail("cmd.user attribute invalid")
+	print "Verify timeout attribute"
+	if cmd.timeout != 123:
+		testCaseFail("cmd.timeout attribute invalid")
+	print "Verify stdout attribute"
+	if cmd.stdout != outbuf:
+		testCaseFail("cmd.stdout attribute invalid")
+	print "Verify stderr attribute"
+	if cmd.stderr != errbuf:
+		testCaseFail("cmd.stderr attribute invalid")
+
+	print "Change user attribute"
+	cmd.user = "root"
+	if cmd.user != "root":
+		testCaseFail("unable to set cmd.user attribute")
+	print "Change timeout attribute"
+	cmd.timeout = 12;
+	if cmd.timeout != 12:
+		testCaseFail("unable to set cmd.timeout attribute")
+	print "Change stdout attribute"
+	cmd.stdout = errbuf;
+	if cmd.stdout != errbuf:
+		testCaseFail("unable to set cmd.stdout attribute")
+	print "Change stderr attribute"
+	cmd.stderr = outbuf;
+	if cmd.stderr != outbuf:
+		testCaseFail("unable to set cmd.stderr attribute")
+
+	# Not yet supported:
+	# useTty
+	# suppressOutput
+except:
+	testCaseException()
+testCaseReport()
+
 testCaseBegin("run command /bin/blablabla (should fail)")
 try:
 	status = target.run("/bin/blablabla")

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -357,6 +357,30 @@ except:
 	testCaseException()
 testCaseReport()
 
+# There's a "line timeout" in the ssh target plugin that wreaks havoc with the regular
+# timeout handling.
+# If that problem is still present, the following will result in a python exception
+# from target.run()
+testCaseBegin("Verify long command timeout")
+try:
+	import time
+
+	print "The next command should sleep for 65 seconds"
+
+	t0 = time.time()
+	st = target.run("sleep 65", timeout = 120)
+	delay = time.time() - t0
+
+	if delay < 65:
+		testCaseFail("command slept for less than 65 seconds (only %u sec)" % delay)
+	elif delay > 67:
+		testCaseFail("command slept for way more than 65 seconds (overall %u sec)" % delay)
+	else:
+		print "Good: Slept for %u seconds" % delay
+except:
+	testCaseException()
+testCaseReport()
+
 testCaseBegin("Verify twopence.Transfer attributes")
 try:
 	xfer = twopence.Transfer("/remote/filename", localfile = "/local/filename", permissions = 0421);


### PR DESCRIPTION
Hi Eric,

this pull request comes with two bugfixes:

 - The line timeout currently makes it impossible to run a command that takes more than 60 seconds
   I've disabled the line timeout in ssh completely, and in virtio I'm at least making sure it is not smaller
   than the command timeout. This needs more work when I'm back

 - In the python module, the Command.timeout attribute expected a string value when being set, and
   would convert that to a long using atol. Changed that to expect an int or long object.
   Before:
    cmd.timeout = "60"
   now:
    cmd.timeout = 60;

The rest of the pull request are test cases and updates to the TODO file.

There is one issue with the virtio protocol that I ran into, which I haven't fixed yet because it probably
requires major surgery and thorough testing. I documented it in the TODO file.

Olaf