### PR TITLE
Python stdin fix

### DIFF
--- a/library/chroot.c
+++ b/library/chroot.c
@@ -102,7 +102,7 @@ __twopence_chroot_open(struct twopence_pipe_target *pipe_handle)
     char *argv[MAX_ARGC + 1];
     int argc = 0, i;
 
-    argv[argc++] = "twopence-server";
+    argv[argc++] = "twopence_test_server";
     if (handle->directory) {
       argv[argc++] = "--root-directory";
       argv[argc++] = handle->directory;

--- a/library/chroot.c
+++ b/library/chroot.c
@@ -115,7 +115,6 @@ __twopence_chroot_open(struct twopence_pipe_target *pipe_handle)
 
     close(fd[0]);
     dup2(fd[1], 0);
-    dup2(fd[1], 1);
 
     server_path = getenv("TWOPENCE_SERVER_PATH");
     if (server_path) {

--- a/library/chroot.c
+++ b/library/chroot.c
@@ -97,9 +97,10 @@ __twopence_chroot_open(struct twopence_pipe_target *pipe_handle)
   }
 
   if (pid == 0) {
+    static const unsigned int MAX_ARGC = 15;
     const char *server_path;
-    char *argv[16];
-    int argc = 0;
+    char *argv[MAX_ARGC + 1];
+    int argc = 0, i;
 
     argv[argc++] = "twopence-server";
     if (handle->directory) {
@@ -108,7 +109,8 @@ __twopence_chroot_open(struct twopence_pipe_target *pipe_handle)
     }
 
     argv[argc++] = "--port-stdio";
-    /* argv[argc++] = "--debug"; */
+    for (i = 0; i < twopence_debug_level && argc < MAX_ARGC; ++i)
+	    argv[argc++] = "--debug";
     argv[argc++] = NULL;
 
     close(fd[0]);

--- a/python/command.c
+++ b/python/command.c
@@ -1,7 +1,7 @@
 /*
 Twopence python bindings
 
-Copyright (C) 2014, 2015 SUSE
+Copyright (C) 2014-2016 SUSE
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -181,8 +181,8 @@ Command_init(twopence_Command *self, PyObject *args, PyObject *kwds)
 	Py_INCREF(stderrObject);
 	self->stderr = stderrObject;
 
-	if (stdinObject == NULL || stdinObject == Py_None) {
-		/* Do not pipe any input to the command */
+	if (stdinObject == NULL) {
+		/* Default: pipe our stdin to the remote command */
 	} else
 	if (PyString_Check(stdinObject)) {
 		char *s;
@@ -191,6 +191,7 @@ Command_init(twopence_Command *self, PyObject *args, PyObject *kwds)
 			return -1;
 		self->stdinPath = twopence_strdup(s);
 	} else {
+		/* This can also be Py_None */
 		Py_INCREF(stdinObject);
 		self->stdin = stdinObject;
 	}
@@ -312,6 +313,9 @@ Command_build(twopence_Command *self, twopence_command_t *cmd)
 			return -1;
 		}
 		twopence_command_iostream_redirect(cmd, TWOPENCE_STDIN, fd, true);
+	} else
+	if (self->stdin == Py_None) {
+		/* Do not pipe anything to the command's stdin */
 	} else
 	if (self->stdin) {
 		if (!Command_redirect_iostream(cmd, TWOPENCE_STDIN, self->stdin, NULL))

--- a/server/main.c
+++ b/server/main.c
@@ -5,7 +5,7 @@ The idea is to avoid interfering with networks test. This enables to test
 even with all network interfaces are shut down.
 
 
-Copyright (C) 2014-2015 SUSE
+Copyright (C) 2014-2016 SUSE
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -374,7 +374,7 @@ int main(int argc, char *argv[])
 		"--port-tcp number:\n"
 		"    create a TCP socket and listen on the given port number for incoming connections\n"
 		"--port-stdio:\n"
-		"    expect an open socket on fd 0/1, and service requests received on this socket\n"
+		"    expect an open socket on fd 0, and service requests received on this socket\n"
 		"    This may be either a connected socket, or a bound socket to listen on\n"
 		"\n"
 		"Supported options:\n"


### PR DESCRIPTION
This patch (which goes on top of pull request 55) fixes the behavior of the python Command class:

  cmd = twopence.Command("some_command")

runs the command and forwards the local stdin to the remote command. However,

  cmd = twopence.Command("some_command", stdin = None)

should really run the command with nothing attached to stdin.