### PR TITLE
Disconnect

### DIFF
--- a/library/chroot.c
+++ b/library/chroot.c
@@ -204,6 +204,7 @@ const struct twopence_plugin twopence_chroot_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };
 
@@ -220,5 +221,6 @@ const struct twopence_plugin twopence_local_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/library/connection.h
+++ b/library/connection.h
@@ -46,6 +46,7 @@ extern bool			twopence_conn_process(twopence_conn_t *conn);
 extern twopence_transaction_t *	twopence_conn_transaction_new(twopence_conn_t *, unsigned int type, const twopence_protocol_state_t *);
 extern int			twopence_conn_xmit_packet(twopence_conn_t *, twopence_buf_t *);
 extern twopence_sock_t *	twopence_conn_accept(twopence_conn_t *);
+extern void			twopence_conn_close(twopence_conn_t *conn);
 extern bool			twopence_conn_is_closed(const twopence_conn_t *);
 extern void			twopence_conn_update_send_keepalive(twopence_conn_t *conn);
 extern void			twopence_conn_update_recv_keepalive(twopence_conn_t *conn);

--- a/library/pipe.c
+++ b/library/pipe.c
@@ -229,7 +229,7 @@ __twopence_pipe_handshake(twopence_sock_t *sock, unsigned int *client_id, unsign
  * Wrap command transaction state into a struct.
  * We may want to reuse the server side transaction code here, at some point.
  */
-twopence_transaction_t *
+static twopence_transaction_t *
 twopence_pipe_transaction_new(struct twopence_pipe_target *handle, unsigned int type)
 {
   twopence_transaction_t *trans;
@@ -574,8 +574,8 @@ twopence_pipe_chat_recv(twopence_target_t *opaque_handle, int xid, const struct 
 // Inject a file into the remote host
 //
 // Returns 0 if everything went fine
-int __twopence_pipe_inject_file
-  (struct twopence_pipe_target *handle, twopence_file_xfer_t *xfer, twopence_status_t *status)
+static int
+__twopence_pipe_inject_file(struct twopence_pipe_target *handle, twopence_file_xfer_t *xfer, twopence_status_t *status)
 {
   twopence_transaction_t *trans;
   twopence_trans_channel_t *channel;
@@ -618,8 +618,9 @@ out:
 // Extract a file from the remote host
 //
 // Returns 0 if everything went fine, or a negative error code if failed
-int _twopence_extract_virtio_serial
-  (struct twopence_pipe_target *handle, twopence_file_xfer_t *xfer, twopence_status_t *status)
+static int
+__twopence_pipe_extract_file(struct twopence_pipe_target *handle, twopence_file_xfer_t *xfer,
+				twopence_status_t *status)
 {
   twopence_transaction_t *trans;
   twopence_trans_channel_t *sink;
@@ -661,8 +662,8 @@ out:
 // Tell the remote test server to exit
 //
 // Returns 0 if everything went fine, or a negative error code if failed
-int _twopence_exit_virtio_serial
-  (struct twopence_pipe_target *handle)
+static int
+__twopence_pipe_exit_remote(struct twopence_pipe_target *handle)
 {
   // Open link for sending interrupt command
   if (__twopence_pipe_open_link(handle) < 0)
@@ -678,8 +679,8 @@ int _twopence_exit_virtio_serial
 // Interrupt current command
 //
 // Returns 0 if everything went fine, or a negative error code if failed
-int _twopence_interrupt_virtio_serial
-  (struct twopence_pipe_target *handle)
+static int
+__twopence_pipe_interrupt_command(struct twopence_pipe_target *handle)
 {
   twopence_transaction_t *trans;
 
@@ -726,8 +727,8 @@ twopence_pipe_set_option(struct twopence_target *opaque_handle, int option, cons
  *
  */
 int
-twopence_pipe_run_test
-  (struct twopence_target *opaque_handle, twopence_command_t *cmd, twopence_status_t *status_ret)
+twopence_pipe_run_test(struct twopence_target *opaque_handle, twopence_command_t *cmd,
+			twopence_status_t *status_ret)
 {
   struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
 
@@ -803,7 +804,7 @@ twopence_pipe_extract_file(struct twopence_target *opaque_handle,
   int rc;
 
   // Extract it
-  rc = _twopence_extract_virtio_serial(handle, xfer, status);
+  rc = __twopence_pipe_extract_file(handle, xfer, status);
   if (rc == 0 && (status->major != 0 || status->minor != 0))
     rc = TWOPENCE_REMOTE_FILE_ERROR;
 
@@ -818,7 +819,7 @@ twopence_pipe_interrupt_command(struct twopence_target *opaque_handle)
 {
   struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
 
-  return _twopence_interrupt_virtio_serial(handle);
+  return __twopence_pipe_interrupt_command(handle);
 }
 
 // Tell the remote test server to exit
@@ -829,7 +830,7 @@ twopence_pipe_exit_remote(struct twopence_target *opaque_handle)
 {
   struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
 
-  return _twopence_exit_virtio_serial(handle);
+  return __twopence_pipe_exit_remote(handle);
 }
 
 // Close the library

--- a/library/pipe.c
+++ b/library/pipe.c
@@ -745,6 +745,9 @@ twopence_pipe_wait(struct twopence_target *opaque_handle, int want_pid, twopence
   twopence_transaction_t *trans = NULL;
   int rc;
 
+  if (handle->connection == NULL)
+    return 0;
+
   twopence_debug("%s: waiting for pid %d", __func__, want_pid);
   while (true) {
     trans = __twopence_pipe_get_completed_transaction(handle, want_pid);

--- a/library/pipe.c
+++ b/library/pipe.c
@@ -676,6 +676,17 @@ out:
   return rc;
 }
 
+//
+static int
+__twopence_pipe_disconnect(struct twopence_pipe_target *handle)
+{
+  if (handle->connection) {
+    twopence_conn_close(handle->connection);
+    twopence_conn_cancel_transactions(handle->connection, TWOPENCE_TRANSPORT_ERROR);
+  }
+  return 0;
+}
+
 // Tell the remote test server to exit
 //
 // Returns 0 if everything went fine, or a negative error code if failed
@@ -840,6 +851,17 @@ twopence_pipe_interrupt_command(struct twopence_target *opaque_handle)
   struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
 
   return __twopence_pipe_interrupt_command(handle);
+}
+
+/*
+ * Disconnect from the SUT
+ */
+int
+twopence_pipe_disconnect(twopence_target_t *opaque_handle)
+{
+  struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
+
+  return __twopence_pipe_disconnect(handle);
 }
 
 // Tell the remote test server to exit

--- a/library/pipe.h
+++ b/library/pipe.h
@@ -62,6 +62,7 @@ extern int	twopence_pipe_inject_file (struct twopence_target *, twopence_file_xf
 extern int	twopence_pipe_extract_file (struct twopence_target *, twopence_file_xfer_t *, twopence_status_t *);
 extern int	twopence_pipe_interrupt_command(struct twopence_target *);
 extern int	twopence_pipe_exit_remote(struct twopence_target *);
+extern int	twopence_pipe_disconnect(twopence_target_t *);
 extern void	twopence_pipe_end(struct twopence_target *);
 
 #endif /* PIPE_H */

--- a/library/serial.c
+++ b/library/serial.c
@@ -140,5 +140,6 @@ const struct twopence_plugin twopence_serial_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/library/tcp.c
+++ b/library/tcp.c
@@ -176,5 +176,6 @@ const struct twopence_plugin twopence_tcp_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/library/twopence.3
+++ b/library/twopence.3
@@ -124,7 +124,7 @@ In order to dispose of a target object, call this function:
 .fi
 .ni
 .PP
-
+See also the description of \fBtwopence_target_disconnect\fP(3) below.
 .\" --------------------------------------------------------------
 .\"
 .\"
@@ -579,7 +579,26 @@ This will not work equally well on all targets. In particular, while the
 SSH protocol does provide for commands to deliver signals to a command
 remotely, this is currently not implemented in openssh's sshd. A workaround
 exists in the twopence library, but it is far from perfect.
-
+.\" --------------------------------------------------------------
+.\"
+.\"
+.SS Disconnecting from the System Under Test
+When using \fBtwopence_target_free\fP(3) to destroy the target handle,
+all state on pending transactions, etc, will also be lost. A less
+destructive approach is to disconnect from the SUT but otherwise
+retain the target handle:
+.PP
+.in +2
+.nf
+.B "int twopence_disconnect(twopence_target_t *target);
+.fi
+.in
+.PP
+This will drop the underlying transport connection, and cancel all
+pending transactions. 
+It will be possible to reap the status of pending commands
+after this, but all attempts to interact with the remote
+system will return TWOPENCE_TRANSPORT_ERROR.
 .\" --------------------------------------------------------------
 .\"
 .\"

--- a/library/twopence.c
+++ b/library/twopence.c
@@ -648,6 +648,15 @@ twopence_exit_remote(struct twopence_target *target)
 }
 
 int
+twopence_disconnect(twopence_target_t *target)
+{
+  if (target->ops->disconnect == NULL)
+    return TWOPENCE_UNSUPPORTED_FUNCTION_ERROR;
+
+  return target->ops->disconnect(target);
+}
+
+int
 twopence_interrupt_command(struct twopence_target *target)
 {
   if (target->ops->interrupt_command == NULL)

--- a/library/twopence.h
+++ b/library/twopence.h
@@ -98,6 +98,7 @@ struct twopence_plugin {
 	int			(*extract_file)(struct twopence_target *, twopence_file_xfer_t *, twopence_status_t *);
 	int			(*exit_remote)(struct twopence_target *);
 	int			(*interrupt_command)(struct twopence_target *);
+	int			(*disconnect)(twopence_target_t *);
 	void			(*end)(struct twopence_target *);
 };
 
@@ -483,6 +484,21 @@ extern int		twopence_recv_file(struct twopence_target *target,
  *   Returns 0 if everything went fine.
  */
 extern int		twopence_exit_remote(struct twopence_target *target);
+
+/*
+ * Disconnect from the SUT, and cancel all pending transactions.
+ *
+ * It will be possible to reap the status of pending commands
+ * after this, but all attempts to interact with the remote
+ * system will return TWOPENCE_TRANSPORT_ERROR.
+ *
+ * Input:
+ *   handle: the handle returned by the initialization function
+ *
+ * Output:
+ *   Returns 0 if everything went fine.
+ */
+extern int		twopence_disconnect(twopence_target_t *target);
 
 /*
  * Interrupt current command

--- a/library/virtio.c
+++ b/library/virtio.c
@@ -135,5 +135,6 @@ const struct twopence_plugin twopence_virtio_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/python/target.c
+++ b/python/target.c
@@ -40,6 +40,7 @@ static PyObject *	Target_sendfile(twopence_Target *self, PyObject *args, PyObjec
 static PyObject *	Target_recvfile(twopence_Target *self, PyObject *args, PyObject *kwds);
 static PyObject *	Target_setenv(twopence_Target *, PyObject *, PyObject *);
 static PyObject *	Target_unsetenv(twopence_Target *, PyObject *, PyObject *);
+static PyObject *	Target_disconnect(twopence_Target *, PyObject *, PyObject *);
 static PyObject *	Target_chat(twopence_Target *, PyObject *, PyObject *);
 
 /*
@@ -87,6 +88,9 @@ static PyMethodDef twopence_targetMethods[] = {
       },
       {	"chat", (PyCFunction) Target_chat, METH_VARARGS | METH_KEYWORDS,
 	"Create a Chat object for the given command"
+      },
+      {	"disconnect", (PyCFunction) Target_disconnect, METH_VARARGS | METH_KEYWORDS,
+	"Close the connection to the target"
       },
 
       {	NULL }
@@ -877,6 +881,23 @@ Target_unsetenv(twopence_Target *self, PyObject *args, PyObject *kwds)
 		return NULL;
 
 	twopence_target_setenv(self->handle, variable, NULL);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+static PyObject *
+Target_disconnect(twopence_Target *self, PyObject *args, PyObject *kwds)
+{
+	static char *kwlist[] = {
+		NULL
+	};
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "", kwlist))
+		return NULL;
+
+	if (self->handle != NULL)
+		twopence_disconnect(self->handle);
 
 	Py_INCREF(Py_None);
 	return Py_None;

--- a/python/target.c
+++ b/python/target.c
@@ -30,17 +30,17 @@ static void		Target_dealloc(twopence_Target *self);
 static PyObject *	Target_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 static int		Target_init(twopence_Target *self, PyObject *args, PyObject *kwds);
 static PyObject *	Target_getattr(twopence_Target *self, char *name);
-static PyObject *	Target_run(PyObject *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_wait(PyObject *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_waitAll(PyObject *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_run(twopence_Target *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_wait(twopence_Target *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_waitAll(twopence_Target *self, PyObject *args, PyObject *kwds);
 static PyObject *	Target_property(twopence_Target *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_inject(PyObject *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_extract(PyObject *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_sendfile(PyObject *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_recvfile(PyObject *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_inject(twopence_Target *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_extract(twopence_Target *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_sendfile(twopence_Target *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_recvfile(twopence_Target *self, PyObject *args, PyObject *kwds);
 static PyObject *	Target_setenv(twopence_Target *, PyObject *, PyObject *);
 static PyObject *	Target_unsetenv(twopence_Target *, PyObject *, PyObject *);
-static PyObject *	Target_chat(PyObject *, PyObject *, PyObject *);
+static PyObject *	Target_chat(twopence_Target *, PyObject *, PyObject *);
 
 /*
  * Define the python bindings of class "Target"
@@ -166,16 +166,6 @@ Target_dealloc(twopence_Target *self)
 	self->handle = NULL;
 
 	drop_object(&self->attrs);
-}
-
-/*
- * Extract twopence target handle from python object.
- * This should really do a type check and throw an exception if it doesn't match
- */
-static struct twopence_target *
-Target_handle(PyObject *self)
-{
-	return ((twopence_Target *) self)->handle;
 }
 
 static PyObject *
@@ -362,7 +352,7 @@ Target_buildCommandStatusShort(twopence_Command *cmdObject, twopence_command_t *
  * To suppress all output, pass "none" objects to 'stdout' und 'stderr'.
  */
 static PyObject *
-Target_run(PyObject *self, PyObject *args, PyObject *kwds)
+Target_run(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	struct twopence_target *handle;
 	twopence_Command *cmdObject = NULL;
@@ -395,8 +385,7 @@ Target_run(PyObject *self, PyObject *args, PyObject *kwds)
 		goto out;
 	}
 
-	if ((handle = Target_handle(self)) == NULL)
-		goto out;
+	handle = self->handle;
 
 	memset(&cmd, 0, sizeof(cmd));
 	if (cmdObject->background) {
@@ -486,13 +475,12 @@ Target_wait_common(twopence_Target *tgtObject, int pid)
 }
 
 static PyObject *
-Target_wait(PyObject *self, PyObject *args, PyObject *kwds)
+Target_wait(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	static char *kwlist[] = {
 		"command",
 		NULL
 	};
-	twopence_Target *tgtObject = (twopence_Target *) self;
 	PyObject *argObject = NULL;
 	int pid = 0;
 
@@ -521,28 +509,24 @@ Target_wait(PyObject *self, PyObject *args, PyObject *kwds)
 		return NULL;
 	}
 
-	return Target_wait_common(tgtObject, pid);
+	return Target_wait_common(self, pid);
 }
 
 /*
  * Wait for all commands to complete
  */
 static PyObject *
-Target_waitAll(PyObject *self, PyObject *args, PyObject *kwds)
+Target_waitAll(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	static char *kwlist[] = {
 		"print_dots",
 		NULL
 	};
-	twopence_target_t *handle;
-	twopence_Target *tgtObject = (twopence_Target *) self;
+	twopence_target_t *handle = self->handle;
 	twopence_Status *result = NULL;
 	int print_dots = 0, ndots = 0;
 
 	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|i", kwlist, &print_dots))
-		return NULL;
-
-	if ((handle = Target_handle(self)) == NULL)
 		return NULL;
 
 	while (true) {
@@ -563,7 +547,7 @@ Target_waitAll(PyObject *self, PyObject *args, PyObject *kwds)
 			break;
 		}
 
-		bg = Target_findBackgrounded(tgtObject, pid);
+		bg = Target_findBackgrounded(self, pid);
 		if (bg == NULL) {
 			if (ndots)
 				printf("\n");
@@ -597,7 +581,7 @@ Target_waitAll(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyObject *
-Target_chat(PyObject *self, PyObject *args, PyObject *kwds)
+Target_chat(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	twopence_Target *tgtObject = (twopence_Target *) self;
 	twopence_Command *cmdObject = NULL;
@@ -684,7 +668,7 @@ failed:
  * inject file into SUT
  */
 static PyObject *
-Target_inject(PyObject *self, PyObject *args, PyObject *kwds)
+Target_inject(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	static char *kwlist[] = {
 		"local",
@@ -693,7 +677,7 @@ Target_inject(PyObject *self, PyObject *args, PyObject *kwds)
 		"mode",
 		NULL
 	};
-	struct twopence_target *handle;
+	struct twopence_target *handle = self->handle;
 	char *sourceFile, *destFile;
 	char *user = "root";
 	int omode = 0644;
@@ -703,10 +687,6 @@ Target_inject(PyObject *self, PyObject *args, PyObject *kwds)
 		return NULL;
 
 	/* printf("inject %s -> %s (user %s, mode 0%o)\n", sourceFile, destFile, user, omode); */
-
-	if ((handle = Target_handle(self)) == NULL)
-		return NULL;
-
 	rc = twopence_inject_file(handle, user, sourceFile, destFile, &remoteRc, 0);
 	if (rc < 0)
 		return twopence_Exception("inject", rc);
@@ -718,7 +698,7 @@ Target_inject(PyObject *self, PyObject *args, PyObject *kwds)
  * extract file from SUT
  */
 static PyObject *
-Target_extract(PyObject *self, PyObject *args, PyObject *kwds)
+Target_extract(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	static char *kwlist[] = {
 		"local",
@@ -727,7 +707,7 @@ Target_extract(PyObject *self, PyObject *args, PyObject *kwds)
 		"mode",
 		NULL
 	};
-	struct twopence_target *handle;
+	struct twopence_target *handle = self->handle;
 	char *sourceFile, *destFile;
 	char *user = "root";
 	int omode = 0644;
@@ -737,9 +717,6 @@ Target_extract(PyObject *self, PyObject *args, PyObject *kwds)
 		return NULL;
 
 	/* printf("extract %s -> %s (user %s, mode 0%o)\n", sourceFile, destFile, user, omode); */
-	if ((handle = Target_handle(self)) == NULL)
-		return NULL;
-
 	rc = twopence_extract_file(handle, user, sourceFile, destFile, &remoteRc, 0);
 	if (rc < 0)
 		return twopence_Exception("extract", rc);
@@ -776,9 +753,9 @@ Taget_send_recv_common(PyObject *args, PyObject *kwds)
  * transfer a file to the SUT
  */
 static PyObject *
-Target_sendfile(PyObject *self, PyObject *args, PyObject *kwds)
+Target_sendfile(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
-	struct twopence_target *handle;
+	struct twopence_target *handle = self->handle;
 	twopence_Transfer *xferObject = NULL;
 	twopence_Status *statusObject;
 	twopence_file_xfer_t xfer;
@@ -794,9 +771,6 @@ Target_sendfile(PyObject *self, PyObject *args, PyObject *kwds)
 
 	if (Transfer_build_send(xferObject, &xfer) < 0)
 		goto out;
-
-	if ((handle = Target_handle(self)) == NULL)
-		return NULL;
 
 	rc = twopence_send_file(handle, &xfer, &status);
 	if (rc < 0) {
@@ -821,9 +795,9 @@ out:
  * transfer a file to the SUT
  */
 static PyObject *
-Target_recvfile(PyObject *self, PyObject *args, PyObject *kwds)
+Target_recvfile(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
-	struct twopence_target *handle;
+	struct twopence_target *handle = self->handle;
 	twopence_Transfer *xferObject = NULL;
 	twopence_Status *statusObject;
 	twopence_file_xfer_t xfer;
@@ -839,9 +813,6 @@ Target_recvfile(PyObject *self, PyObject *args, PyObject *kwds)
 
 	if (Transfer_build_recv(xferObject, &xfer) < 0)
 		goto out;
-
-	if ((handle = Target_handle(self)) == NULL)
-		return NULL;
 
 	rc = twopence_recv_file(handle, &xfer, &status);
 	if (rc < 0) {

--- a/python/twopence.3py
+++ b/python/twopence.3py
@@ -42,6 +42,18 @@ Please do not use the \fBattrs\fP argument.
 .\" --------------------------------------------------------------
 .\"
 .\"
+.SS Target management methods
+.\" --------------------------------------------------------------
+The \fBTarget\fP class supports the following methods:
+.TP
+.BR disconnect ()
+This will cancel all pending transactions. Calling \fBwait()\fP
+on any of these will raise a transport error exception.
+The handle should be considered invalid afterwards, and should not
+be used afterwards for anything other than waiting for commands.
+.\" --------------------------------------------------------------
+.\"
+.\"
 .SS Target Object Attributes
 .\" --------------------------------------------------------------
 The target object supports these attributes:


### PR DESCRIPTION
This patch set adds a new target operation that lets you disconnect from the target without
having to destroy the target handle. The purpose of this functionality is to be able to collect
the status of all canceled commands after this has happened.