### PR TITLE
Ctcs2 support

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -35,6 +35,7 @@ LIB_OBJS= twopence.o \
 	  connection.o \
 	  iostream.o \
 	  socket.o \
+	  timer.o \
 	  buffer.o \
 	  logging.o \
 	  utils.o

--- a/library/chroot.c
+++ b/library/chroot.c
@@ -204,6 +204,7 @@ const struct twopence_plugin twopence_chroot_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };
 
@@ -220,5 +221,6 @@ const struct twopence_plugin twopence_local_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/library/chroot.c
+++ b/library/chroot.c
@@ -204,6 +204,7 @@ const struct twopence_plugin twopence_chroot_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.cancel_transactions = twopence_pipe_cancel_transactions,
 	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };
@@ -221,6 +222,7 @@ const struct twopence_plugin twopence_local_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.cancel_transactions = twopence_pipe_cancel_transactions,
 	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/library/connection.c
+++ b/library/connection.c
@@ -317,10 +317,12 @@ twopence_conn_cancel_transactions(twopence_conn_t *conn, int error)
 {
 	twopence_transaction_t *trans;
 
-	if (conn->transactions.head)
+	twopence_debug("%s(%s)", __func__, twopence_strerror(error));
+
+	if (conn->transactions.head
+	 && error != TWOPENCE_COMMAND_CANCELED_ERROR)
 		twopence_log_error("remote closed the connection while there were pending transactions");
 
-	twopence_debug("%s()", __func__);
 	while ((trans = conn->transactions.head) != NULL) {
 		twopence_transaction_set_error(trans, error);
 		twopence_conn_transaction_complete(conn, trans);

--- a/library/connection.h
+++ b/library/connection.h
@@ -46,6 +46,7 @@ extern bool			twopence_conn_process(twopence_conn_t *conn);
 extern twopence_transaction_t *	twopence_conn_transaction_new(twopence_conn_t *, unsigned int type, const twopence_protocol_state_t *);
 extern int			twopence_conn_xmit_packet(twopence_conn_t *, twopence_buf_t *);
 extern twopence_sock_t *	twopence_conn_accept(twopence_conn_t *);
+extern void			twopence_conn_close(twopence_conn_t *conn);
 extern bool			twopence_conn_is_closed(const twopence_conn_t *);
 extern void			twopence_conn_update_send_keepalive(twopence_conn_t *conn);
 extern void			twopence_conn_update_recv_keepalive(twopence_conn_t *conn);

--- a/library/pipe.c
+++ b/library/pipe.c
@@ -357,7 +357,10 @@ __twopence_transaction_run(struct twopence_pipe_target *handle, twopence_transac
     }
   }
 
-  *status = trans->client.status_ret;
+  status->pid = trans->id;
+  status->major = trans->client.status_ret.major;
+  status->minor = trans->client.status_ret.minor;
+
   if (trans->client.exception < 0)
     return trans->client.exception;
 
@@ -798,14 +801,18 @@ twopence_pipe_wait(struct twopence_target *opaque_handle, int want_pid, twopence
   if (trans == NULL)
     return 0;
 
+  status->pid = trans->id;
+
   twopence_debug("%s: returning status for transaction %s", __func__, twopence_transaction_describe(trans));
   if (trans->client.exception < 0) {
     rc = trans->client.exception;
   } else {
-    *status = trans->client.status_ret;
+    status->major = trans->client.status_ret.major;
+    status->minor = trans->client.status_ret.minor;
     rc = trans->id;
   }
 
+  status->pid = trans->id;
   twopence_transaction_free(trans);
   return rc;
 }

--- a/library/pipe.c
+++ b/library/pipe.c
@@ -229,7 +229,7 @@ __twopence_pipe_handshake(twopence_sock_t *sock, unsigned int *client_id, unsign
  * Wrap command transaction state into a struct.
  * We may want to reuse the server side transaction code here, at some point.
  */
-twopence_transaction_t *
+static twopence_transaction_t *
 twopence_pipe_transaction_new(struct twopence_pipe_target *handle, unsigned int type)
 {
   twopence_transaction_t *trans;
@@ -574,8 +574,8 @@ twopence_pipe_chat_recv(twopence_target_t *opaque_handle, int xid, const struct 
 // Inject a file into the remote host
 //
 // Returns 0 if everything went fine
-int __twopence_pipe_inject_file
-  (struct twopence_pipe_target *handle, twopence_file_xfer_t *xfer, twopence_status_t *status)
+static int
+__twopence_pipe_inject_file(struct twopence_pipe_target *handle, twopence_file_xfer_t *xfer, twopence_status_t *status)
 {
   twopence_transaction_t *trans;
   twopence_trans_channel_t *channel;
@@ -618,8 +618,9 @@ out:
 // Extract a file from the remote host
 //
 // Returns 0 if everything went fine, or a negative error code if failed
-int _twopence_extract_virtio_serial
-  (struct twopence_pipe_target *handle, twopence_file_xfer_t *xfer, twopence_status_t *status)
+static int
+__twopence_pipe_extract_file(struct twopence_pipe_target *handle, twopence_file_xfer_t *xfer,
+				twopence_status_t *status)
 {
   twopence_transaction_t *trans;
   twopence_trans_channel_t *sink;
@@ -661,8 +662,8 @@ out:
 // Tell the remote test server to exit
 //
 // Returns 0 if everything went fine, or a negative error code if failed
-int _twopence_exit_virtio_serial
-  (struct twopence_pipe_target *handle)
+static int
+__twopence_pipe_exit_remote(struct twopence_pipe_target *handle)
 {
   // Open link for sending interrupt command
   if (__twopence_pipe_open_link(handle) < 0)
@@ -678,8 +679,8 @@ int _twopence_exit_virtio_serial
 // Interrupt current command
 //
 // Returns 0 if everything went fine, or a negative error code if failed
-int _twopence_interrupt_virtio_serial
-  (struct twopence_pipe_target *handle)
+static int
+__twopence_pipe_interrupt_command(struct twopence_pipe_target *handle)
 {
   twopence_transaction_t *trans;
 
@@ -726,8 +727,8 @@ twopence_pipe_set_option(struct twopence_target *opaque_handle, int option, cons
  *
  */
 int
-twopence_pipe_run_test
-  (struct twopence_target *opaque_handle, twopence_command_t *cmd, twopence_status_t *status_ret)
+twopence_pipe_run_test(struct twopence_target *opaque_handle, twopence_command_t *cmd,
+			twopence_status_t *status_ret)
 {
   struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
 
@@ -803,7 +804,7 @@ twopence_pipe_extract_file(struct twopence_target *opaque_handle,
   int rc;
 
   // Extract it
-  rc = _twopence_extract_virtio_serial(handle, xfer, status);
+  rc = __twopence_pipe_extract_file(handle, xfer, status);
   if (rc == 0 && (status->major != 0 || status->minor != 0))
     rc = TWOPENCE_REMOTE_FILE_ERROR;
 
@@ -818,7 +819,7 @@ twopence_pipe_interrupt_command(struct twopence_target *opaque_handle)
 {
   struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
 
-  return _twopence_interrupt_virtio_serial(handle);
+  return __twopence_pipe_interrupt_command(handle);
 }
 
 // Tell the remote test server to exit
@@ -829,7 +830,7 @@ twopence_pipe_exit_remote(struct twopence_target *opaque_handle)
 {
   struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
 
-  return _twopence_exit_virtio_serial(handle);
+  return __twopence_pipe_exit_remote(handle);
 }
 
 // Close the library

--- a/library/pipe.c
+++ b/library/pipe.c
@@ -745,6 +745,9 @@ twopence_pipe_wait(struct twopence_target *opaque_handle, int want_pid, twopence
   twopence_transaction_t *trans = NULL;
   int rc;
 
+  if (handle->connection == NULL)
+    return 0;
+
   twopence_debug("%s: waiting for pid %d", __func__, want_pid);
   while (true) {
     trans = __twopence_pipe_get_completed_transaction(handle, want_pid);

--- a/library/pipe.c
+++ b/library/pipe.c
@@ -687,6 +687,14 @@ __twopence_pipe_disconnect(struct twopence_pipe_target *handle)
   return 0;
 }
 
+static int
+__twopence_pipe_cancel_transactions(struct twopence_pipe_target *handle)
+{
+  if (handle->connection)
+    twopence_conn_cancel_transactions(handle->connection, TWOPENCE_COMMAND_CANCELED_ERROR);
+  return 0;
+}
+
 // Tell the remote test server to exit
 //
 // Returns 0 if everything went fine, or a negative error code if failed
@@ -851,6 +859,17 @@ twopence_pipe_interrupt_command(struct twopence_target *opaque_handle)
   struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
 
   return __twopence_pipe_interrupt_command(handle);
+}
+
+/*
+ * Cancel all pending transactions
+ */
+int
+twopence_pipe_cancel_transactions(twopence_target_t *opaque_handle)
+{
+  struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
+
+  return __twopence_pipe_cancel_transactions(handle);
 }
 
 /*

--- a/library/pipe.c
+++ b/library/pipe.c
@@ -676,6 +676,17 @@ out:
   return rc;
 }
 
+//
+static int
+__twopence_pipe_disconnect(struct twopence_pipe_target *handle)
+{
+  if (handle->connection) {
+    twopence_conn_close(handle->connection);
+    twopence_conn_cancel_transactions(handle->connection, TWOPENCE_TRANSPORT_ERROR);
+  }
+  return 0;
+}
+
 // Tell the remote test server to exit
 //
 // Returns 0 if everything went fine, or a negative error code if failed
@@ -840,6 +851,17 @@ twopence_pipe_interrupt_command(struct twopence_target *opaque_handle)
   struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
 
   return __twopence_pipe_interrupt_command(handle);
+}
+
+/*
+ * Disconnect from the SUT
+ */
+int
+twopence_pipe_disconnect(twopence_target_t *opaque_handle)
+{
+  struct twopence_pipe_target *handle = (struct twopence_pipe_target *) opaque_handle;
+
+  return __twopence_pipe_disconnect(handle);
 }
 
 // Tell the remote test server to exit

--- a/library/pipe.c
+++ b/library/pipe.c
@@ -476,9 +476,6 @@ __twopence_pipe_command(struct twopence_pipe_target *handle, twopence_command_t 
   twopence_transaction_t *trans;
   int rc;
 
-  // By default, no major and no minor
-  memset(status_ret, 0, sizeof(*status_ret));
-
   // Check that the username is valid
   if (_twopence_invalid_username(cmd->user))
     return TWOPENCE_PARAMETER_ERROR;

--- a/library/pipe.h
+++ b/library/pipe.h
@@ -62,6 +62,7 @@ extern int	twopence_pipe_inject_file (struct twopence_target *, twopence_file_xf
 extern int	twopence_pipe_extract_file (struct twopence_target *, twopence_file_xfer_t *, twopence_status_t *);
 extern int	twopence_pipe_interrupt_command(struct twopence_target *);
 extern int	twopence_pipe_exit_remote(struct twopence_target *);
+extern int	twopence_pipe_disconnect(twopence_target_t *);
 extern void	twopence_pipe_end(struct twopence_target *);
 
 #endif /* PIPE_H */

--- a/library/pipe.h
+++ b/library/pipe.h
@@ -63,6 +63,7 @@ extern int	twopence_pipe_extract_file (struct twopence_target *, twopence_file_x
 extern int	twopence_pipe_interrupt_command(struct twopence_target *);
 extern int	twopence_pipe_exit_remote(struct twopence_target *);
 extern int	twopence_pipe_disconnect(twopence_target_t *);
+extern int	twopence_pipe_cancel_transactions(twopence_target_t *);
 extern void	twopence_pipe_end(struct twopence_target *);
 
 #endif /* PIPE_H */

--- a/library/serial.c
+++ b/library/serial.c
@@ -140,6 +140,7 @@ const struct twopence_plugin twopence_serial_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.cancel_transactions = twopence_pipe_cancel_transactions,
 	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/library/serial.c
+++ b/library/serial.c
@@ -140,5 +140,6 @@ const struct twopence_plugin twopence_serial_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/library/ssh.c
+++ b/library/ssh.c
@@ -976,6 +976,8 @@ __twopence_ssh_command_ssh
   if (trans == NULL)
     return TWOPENCE_OPEN_SESSION_ERROR;
 
+  status_ret->pid = trans->pid;
+
   rc = __twopence_ssh_transaction_open_session(trans, cmd->user);
   if (rc != 0) {
     __twopence_ssh_transaction_free(trans);
@@ -1015,7 +1017,8 @@ __twopence_ssh_command_ssh
   if (trans->exception) {
     rc = trans->exception;
   } else {
-    *status_ret = trans->status;
+    status_ret->major = trans->status.major;
+    status_ret->minor = trans->status.minor;
     rc = 0;
   }
 
@@ -1375,10 +1378,12 @@ twopence_ssh_wait(struct twopence_target *opaque_handle, int want_pid, twopence_
 
   assert(trans->done);
 
+  status->pid = trans->pid;
   if (trans->exception < 0) {
     rc = trans->exception;
   } else {
-    *status = trans->status;
+    status->major = trans->status.major;
+    status->minor = trans->status.minor;
     rc = trans->pid;
   }
 

--- a/library/ssh.c
+++ b/library/ssh.c
@@ -503,7 +503,7 @@ __twopence_ssh_transaction_get_exit_status(twopence_ssh_transaction_t *trans)
 
   if (trans->channel == NULL) {
     __twopence_ssh_transaction_fail(trans, TWOPENCE_TRANSPORT_ERROR);
-    return -1;
+    return TWOPENCE_TRANSPORT_ERROR;
   }
 
   /*
@@ -530,10 +530,8 @@ __twopence_ssh_transaction_get_exit_status(twopence_ssh_transaction_t *trans)
     twopence_log_error("transaction %d has no exit status", trans->pid);
     status->major = 0;
     (void) ssh_channel_get_exit_status(trans->channel);
-    if (!trans->have_exit_status) {
-      twopence_log_error("ssh_channel_get_exit_status didn't set the exit status either, faking it");
-      trans->status.major = EIO;
-    }
+    if (!trans->have_exit_status)
+      return TWOPENCE_TRANSPORT_ERROR;
   }
 
   twopence_debug("exit status is %d/%d\n", status->major, status->minor);

--- a/library/ssh.c
+++ b/library/ssh.c
@@ -1550,6 +1550,18 @@ twopence_ssh_interrupt_command(struct twopence_target *opaque_handle)
   return __twopence_ssh_interrupt_ssh(handle);
 }
 
+// Cancel all pending transactions
+//
+// Returns 0 if everything went fine
+static int
+twopence_ssh_cancel_transactions(struct twopence_target *opaque_handle)
+{
+  struct twopence_ssh_target *handle = (struct twopence_ssh_target *) opaque_handle;
+
+  __twopence_ssh_cancel_transactions(handle, TWOPENCE_COMMAND_CANCELED_ERROR);
+  return 0;
+}
+
 // Disconnect from remote, and cancel all pending transactions
 //
 // Returns 0 if everything went fine
@@ -1603,6 +1615,7 @@ const struct twopence_plugin twopence_ssh_ops = {
 	.extract_file = twopence_ssh_extract_file,
 	.exit_remote = twopence_ssh_exit_remote,
 	.interrupt_command = twopence_ssh_interrupt_command,
+	.cancel_transactions = twopence_ssh_cancel_transactions,
 	.disconnect = twopence_ssh_disconnect,
 	.end = twopence_ssh_end,
 };

--- a/library/ssh.c
+++ b/library/ssh.c
@@ -715,6 +715,8 @@ __twopence_ssh_poll(struct twopence_ssh_target *handle)
       }
     }
 
+    twopence_timers_update_timeout(&timeout);
+
     twopence_debug("polling for events; timeout=%ld\n", twopence_timeout_msec(&timeout));
     rc = ssh_event_dopoll(event, twopence_timeout_msec(&timeout));
 
@@ -728,6 +730,11 @@ __twopence_ssh_poll(struct twopence_ssh_target *handle)
       twopence_debug("ssh_event_dopoll() returns error");
       return TWOPENCE_INTERNAL_ERROR;
     }
+
+    /* We do this as the last thing before returning, in order to minimize the
+     * risk of harmful user behavior */
+    twopence_timers_run();
+
   } while (true);
 
   return 0;

--- a/library/ssh.c
+++ b/library/ssh.c
@@ -1339,9 +1339,6 @@ twopence_ssh_run_test
   if (cmd->command == NULL)
     return TWOPENCE_PARAMETER_ERROR;
 
-  /* 'major' makes no sense for SSH and 'minor' defaults to 0 */
-  memset(status_ret, 0, sizeof(*status_ret));
-
   // Execute the command
   return __twopence_ssh_command_ssh(handle, cmd, status_ret);
 }

--- a/library/tcp.c
+++ b/library/tcp.c
@@ -176,5 +176,6 @@ const struct twopence_plugin twopence_tcp_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/library/tcp.c
+++ b/library/tcp.c
@@ -176,6 +176,7 @@ const struct twopence_plugin twopence_tcp_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.cancel_transactions = twopence_pipe_cancel_transactions,
 	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/library/timer.c
+++ b/library/timer.c
@@ -1,0 +1,324 @@
+/*
+ * Timer handling routines
+ *
+ * Copyright (C) 2014-2016 SUSE
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <sys/types.h>
+#include <sys/time.h>
+
+#include <errno.h>
+#include <unistd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdint.h>
+#include <assert.h>
+
+#include "utils.h"
+#include "twopence.h"
+
+static unsigned int		__global_timer_id = 1;
+static twopence_timer_list_t	__global_timer_list;
+
+/*
+ * List helper functions
+ */
+static inline void
+__twopence_timer_insert(twopence_timer_t **pos, twopence_timer_t *timer)
+{
+	timer->next = *pos;
+	timer->prev = pos;
+	*pos = timer;
+}
+
+static inline void
+__twopence_timer_unlink(twopence_timer_t *timer)
+{
+	twopence_timer_t **pos, *next;
+
+	next = timer->next;
+	if ((pos = timer->prev) != NULL) {
+		*pos = next;
+		if (next)
+			next->prev = pos;
+
+		timer->prev = NULL;
+		timer->next = NULL;
+	}
+}
+
+
+int
+twopence_timer_create(unsigned long timeout_ms, twopence_timer_t **timer_ret)
+{
+	struct timeval now;
+	twopence_timer_t *timer;
+
+	timer = twopence_calloc(1, sizeof(*timer));
+	timer->refcount = 1;
+	timer->id = __global_timer_id++;
+
+	gettimeofday(&now, NULL);
+	timer->runtime.tv_sec = timeout_ms / 1000;
+	timer->runtime.tv_usec = (timeout_ms % 1000) * 1000;
+	timeradd(&now, &timer->runtime, &timer->expires);
+
+	timer->state = TWOPENCE_TIMER_STATE_ACTIVE;
+	twopence_timer_list_insert(&__global_timer_list, timer);
+
+	twopence_debug("Created timer %u", timer->id);
+	*timer_ret = timer;
+
+	return 0;
+}
+
+void
+twopence_timer_set_callback(twopence_timer_t *timer, void (*callback)(twopence_timer_t *, void *), void *user_data)
+{
+	timer->callback = callback;
+	timer->user_data = user_data;
+}
+
+static void
+__twopence_timer_free(twopence_timer_t *timer)
+{
+	assert(timer->prev == NULL);
+	free(timer);
+}
+
+void
+twopence_timer_hold(twopence_timer_t *timer)
+{
+	assert(timer->refcount);
+	timer->refcount ++;
+}
+
+void
+twopence_timer_release(twopence_timer_t *timer)
+{
+	assert(timer->refcount);
+	if (--(timer->refcount) == 0)
+		__twopence_timer_free(timer);
+}
+
+void
+twopence_timer_cancel(twopence_timer_t *timer)
+{
+	if (timer->state == TWOPENCE_TIMER_STATE_ACTIVE
+	 || timer->state == TWOPENCE_TIMER_STATE_PAUSED
+	 || timer->state == TWOPENCE_TIMER_STATE_CANCELLED) {
+		timer->state = TWOPENCE_TIMER_STATE_CANCELLED;
+		__twopence_timer_unlink(timer);
+	}
+}
+
+void
+twopence_timer_pause(twopence_timer_t *timer)
+{
+	/* silently ignore duplicate calls to pause a timer */
+	if (timer->state == TWOPENCE_TIMER_STATE_PAUSED)
+		return;
+
+	if (timer->state == TWOPENCE_TIMER_STATE_ACTIVE) {
+		struct timeval now;
+
+		gettimeofday(&now, NULL);
+		if (timercmp(&now, &timer->expires, <))
+			timersub(&timer->expires, &now, &timer->runtime);
+		else
+			timerclear(&timer->runtime);
+		timerclear(&timer->expires);
+
+		timer->state = TWOPENCE_TIMER_STATE_PAUSED;
+	}
+}
+
+void
+twopence_timer_unpause(twopence_timer_t *timer)
+{
+	if (timer->state == TWOPENCE_TIMER_STATE_PAUSED) {
+		struct timeval now;
+
+		gettimeofday(&now, NULL);
+		timeradd(&timer->runtime, &now, &timer->expires);
+		timer->state = TWOPENCE_TIMER_STATE_ACTIVE;
+	}
+}
+
+long
+twopence_timer_remaining(const twopence_timer_t *timer)
+{
+	struct timeval now, delta;
+
+	switch (timer->state) {
+	case TWOPENCE_TIMER_STATE_ACTIVE:
+		gettimeofday(&now, NULL);
+		if (timercmp(&now, &timer->expires, <)) {
+			timersub(&timer->expires, &now, &delta);
+			return 1000 * delta.tv_sec + delta.tv_usec / 1000;
+		}
+
+		return 0;
+
+	default:
+		return 0;
+	}
+}
+
+void
+twopence_timer_kill(twopence_timer_t *timer)
+{
+	timer->state = TWOPENCE_TIMER_STATE_DEAD;
+	timer->callback = NULL;
+
+	__twopence_timer_unlink(timer);
+	twopence_timer_release(timer);
+}
+
+static void
+__twopence_timer_mark_expired(twopence_timer_t *timer)
+{
+	twopence_debug("Timer %u expired", timer->id);
+	timer->state = TWOPENCE_TIMER_STATE_EXPIRED;
+	timerclear(&timer->expires);
+
+	/* Do /not/ invoke the callback yet - we may be deep inside
+	 * some transport code, which may or may not be re-entrant.
+	 * We do this at a later point, from twopence_timer_list_reap()
+	 */
+}
+
+void
+twopence_timer_list_insert(twopence_timer_list_t *list, twopence_timer_t *timer)
+{
+	assert(timerisset(&timer->expires));
+	assert(timer->prev == NULL);
+	__twopence_timer_insert(&list->head, timer);
+}
+
+void
+twopence_timer_list_move(twopence_timer_list_t *list, twopence_timer_t *timer)
+{
+	__twopence_timer_unlink(timer);
+	__twopence_timer_insert(&list->head, timer);
+}
+
+/*
+ * Walk the list of timers, and update the twopence_timeout_t to reflect the
+ * point in time when the next timer expires.
+ * If a timer has already expired, this will result in a timeout of 0,
+ * and the respective time is moved to state TWOPENCE_TIMER_STATE_EXPIRED.
+ */
+void
+twopence_timer_list_update_timeout(twopence_timer_list_t *list, twopence_timeout_t *tmo)
+{
+	twopence_timer_t *t;
+
+	for (t = list->head; t; t = t->next) {
+		/* If the timer's expiry time is in the past,
+		 * twopence_timeout_update() will return false
+		 * and set tmo->expired = true;
+		 */
+		if (t->state == TWOPENCE_TIMER_STATE_ACTIVE
+		 && !twopence_timeout_update(tmo, &t->expires))
+			__twopence_timer_mark_expired(t);
+	}
+}
+
+void
+twopence_timer_list_expire(twopence_timer_list_t *list)
+{
+	twopence_timeout_t tmo;
+
+	twopence_timeout_init(&tmo);
+	twopence_timer_list_update_timeout(list, &tmo);
+}
+
+void
+twopence_timer_list_reap(twopence_timer_list_t *list, twopence_timer_list_t *expired)
+{
+	twopence_timer_t *t, *next;
+
+	for (t = list->head; t; t = next) {
+		next = t->next;
+
+		if (t->state == TWOPENCE_TIMER_STATE_EXPIRED
+		 || t->state == TWOPENCE_TIMER_STATE_CANCELLED) {
+			twopence_debug("Reaping timer %u (state %d)", t->id, t->state);
+			twopence_timer_list_move(expired, t);
+		}
+	}
+}
+
+void
+twopence_timer_list_invoke(twopence_timer_list_t *list)
+{
+	twopence_timer_t *t;
+
+	while ((t = list->head) != NULL) {
+		if (t->state == TWOPENCE_TIMER_STATE_EXPIRED && t->callback) {
+			twopence_debug("Invoking timer %u", t->id);
+			t->callback(t, t->user_data);
+		}
+
+		twopence_timer_kill(t);
+	}
+}
+
+
+void
+twopence_timer_list_destroy(twopence_timer_list_t *list)
+{
+	twopence_timer_t *t;
+
+	while ((t = list->head) != NULL)
+		twopence_timer_kill(t);
+}
+
+void
+twopence_timers_update_timeout(twopence_timeout_t *tmo)
+{
+	twopence_timer_list_update_timeout(&__global_timer_list, tmo);
+}
+
+void
+twopence_timers_run(void)
+{
+	twopence_timer_list_t expired = { .head = NULL };
+	twopence_timeout_t timeout;
+
+	/* Do another pass over the list, and catch timers that have
+	 * expired since the last inspection.
+	 *
+	 * We do this because the usual approach is
+	 *
+	 *   twopence_timers_update_timeout(...);
+	 *   poll(..)
+	 *   twopence_timers_run();
+	 *
+	 * So we have to account for the fact that we spent some time
+	 * inside poll()
+	 */
+	twopence_timeout_init(&timeout);
+	twopence_timer_list_update_timeout(&__global_timer_list, &timeout);
+
+	twopence_timer_list_reap(&__global_timer_list, &expired);
+	twopence_timer_list_invoke(&expired);
+	twopence_timer_list_destroy(&expired);
+}

--- a/library/transaction.c
+++ b/library/transaction.c
@@ -335,6 +335,17 @@ twopence_transaction_send_command(twopence_transaction_t *trans, const twopence_
 	return 0;
 }
 
+int
+twopence_transaction_send_interrupt(twopence_transaction_t *trans)
+{
+	twopence_buf_t *bp;
+
+	bp = twopence_protocol_build_simple_packet_ps(&trans->ps, TWOPENCE_PROTO_TYPE_INTR);
+	if (twopence_sock_xmit(trans->socket, bp) < 0)
+		return TWOPENCE_SEND_COMMAND_ERROR;
+	return 0;
+}
+
 twopence_trans_channel_t *
 twopence_transaction_attach_local_sink(twopence_transaction_t *trans, uint16_t id, int fd)
 {

--- a/library/transaction.h
+++ b/library/transaction.h
@@ -81,6 +81,7 @@ extern const char *		twopence_transaction_describe(const twopence_transaction_t 
 extern int			twopence_transaction_send_extract(twopence_transaction_t *, const twopence_file_xfer_t *);
 extern int			twopence_transaction_send_inject(twopence_transaction_t *, const twopence_file_xfer_t *);
 extern int			twopence_transaction_send_command(twopence_transaction_t *, const twopence_command_t *);
+extern int			twopence_transaction_send_interrupt(twopence_transaction_t *);
 extern twopence_trans_channel_t *twopence_transaction_attach_local_sink(twopence_transaction_t *trans, uint16_t id, int fd);
 extern twopence_trans_channel_t *twopence_transaction_attach_local_source(twopence_transaction_t *trans, uint16_t id, int fd);
 extern twopence_trans_channel_t *twopence_transaction_attach_local_sink_stream(twopence_transaction_t *trans, uint16_t id, twopence_iostream_t *);

--- a/library/twopence.3
+++ b/library/twopence.3
@@ -124,7 +124,7 @@ In order to dispose of a target object, call this function:
 .fi
 .ni
 .PP
-
+See also the description of \fBtwopence_target_disconnect\fP(3) below.
 .\" --------------------------------------------------------------
 .\"
 .\"
@@ -579,7 +579,26 @@ This will not work equally well on all targets. In particular, while the
 SSH protocol does provide for commands to deliver signals to a command
 remotely, this is currently not implemented in openssh's sshd. A workaround
 exists in the twopence library, but it is far from perfect.
-
+.\" --------------------------------------------------------------
+.\"
+.\"
+.SS Disconnecting from the System Under Test
+When using \fBtwopence_target_free\fP(3) to destroy the target handle,
+all state on pending transactions, etc, will also be lost. A less
+destructive approach is to disconnect from the SUT but otherwise
+retain the target handle:
+.PP
+.in +2
+.nf
+.B "int twopence_disconnect(twopence_target_t *target);
+.fi
+.in
+.PP
+This will drop the underlying transport connection, and cancel all
+pending transactions. 
+It will be possible to reap the status of pending commands
+after this, but all attempts to interact with the remote
+system will return TWOPENCE_TRANSPORT_ERROR.
 .\" --------------------------------------------------------------
 .\"
 .\"

--- a/library/twopence.c
+++ b/library/twopence.c
@@ -648,6 +648,15 @@ twopence_exit_remote(struct twopence_target *target)
 }
 
 int
+twopence_cancel_transactions(twopence_target_t *target)
+{
+  if (target->ops->cancel_transactions == NULL)
+    return TWOPENCE_UNSUPPORTED_FUNCTION_ERROR;
+
+  return target->ops->cancel_transactions(target);
+}
+
+int
 twopence_disconnect(twopence_target_t *target)
 {
   if (target->ops->disconnect == NULL)
@@ -713,6 +722,8 @@ twopence_strerror(int rc)
       return "Protocol versions not compatible between client and server";
     case TWOPENCE_INVALID_TRANSACTION:
       return "Invalid transaction ID";
+    case TWOPENCE_COMMAND_CANCELED_ERROR:
+      return "Command canceled by user";
   }
   return "Unknow error";
 }

--- a/library/twopence.c
+++ b/library/twopence.c
@@ -209,6 +209,8 @@ twopence_target_passenv(twopence_target_t *target, const char *name)
 int
 twopence_run_test(struct twopence_target *target, twopence_command_t *cmd, twopence_status_t *status)
 {
+  memset(status, 0, sizeof(*status));
+
   if (target->ops->run_test == NULL)
     return TWOPENCE_UNSUPPORTED_FUNCTION_ERROR;
 
@@ -227,6 +229,8 @@ twopence_run_test(struct twopence_target *target, twopence_command_t *cmd, twope
 int
 twopence_wait(struct twopence_target *target, int pid, twopence_status_t *status)
 {
+  memset(status, 0, sizeof(*status));
+
   if (target->ops->wait == NULL)
     return TWOPENCE_UNSUPPORTED_FUNCTION_ERROR;
 
@@ -576,6 +580,8 @@ twopence_inject_file
 int
 twopence_send_file(struct twopence_target *target, twopence_file_xfer_t *xfer, twopence_status_t *status)
 {
+  memset(status, 0, sizeof(*status));
+
   if (target->ops->inject_file == NULL)
     return TWOPENCE_UNSUPPORTED_FUNCTION_ERROR;
 
@@ -587,7 +593,6 @@ twopence_send_file(struct twopence_target *target, twopence_file_xfer_t *xfer, t
   if (xfer->remote.mode == 0)
     xfer->remote.mode = 0644;
 
-  memset(status, 0, sizeof(*status));
   return target->ops->inject_file(target, xfer, status);
 }
 
@@ -623,6 +628,8 @@ twopence_extract_file
 int
 twopence_recv_file(struct twopence_target *target, twopence_file_xfer_t *xfer, twopence_status_t *status)
 {
+  memset(status, 0, sizeof(*status));
+
   if (target->ops->inject_file == NULL)
     return TWOPENCE_UNSUPPORTED_FUNCTION_ERROR;
 
@@ -634,7 +641,6 @@ twopence_recv_file(struct twopence_target *target, twopence_file_xfer_t *xfer, t
   if (xfer->remote.mode == 0)
     xfer->remote.mode = 0644;
 
-  memset(status, 0, sizeof(*status));
   return target->ops->extract_file(target, xfer, status);
 }
 

--- a/library/twopence.c
+++ b/library/twopence.c
@@ -648,6 +648,15 @@ twopence_exit_remote(struct twopence_target *target)
 }
 
 int
+twopence_disconnect(twopence_target_t *target)
+{
+  if (target->ops->disconnect == NULL)
+    return TWOPENCE_UNSUPPORTED_FUNCTION_ERROR;
+
+  return target->ops->disconnect(target);
+}
+
+int
 twopence_interrupt_command(struct twopence_target *target)
 {
   if (target->ops->interrupt_command == NULL)

--- a/library/twopence.h
+++ b/library/twopence.h
@@ -98,6 +98,7 @@ struct twopence_plugin {
 	int			(*extract_file)(struct twopence_target *, twopence_file_xfer_t *, twopence_status_t *);
 	int			(*exit_remote)(struct twopence_target *);
 	int			(*interrupt_command)(struct twopence_target *);
+	int			(*disconnect)(twopence_target_t *);
 	void			(*end)(struct twopence_target *);
 };
 
@@ -483,6 +484,21 @@ extern int		twopence_recv_file(struct twopence_target *target,
  *   Returns 0 if everything went fine.
  */
 extern int		twopence_exit_remote(struct twopence_target *target);
+
+/*
+ * Disconnect from the SUT, and cancel all pending transactions.
+ *
+ * It will be possible to reap the status of pending commands
+ * after this, but all attempts to interact with the remote
+ * system will return TWOPENCE_TRANSPORT_ERROR.
+ *
+ * Input:
+ *   handle: the handle returned by the initialization function
+ *
+ * Output:
+ *   Returns 0 if everything went fine.
+ */
+extern int		twopence_disconnect(twopence_target_t *target);
 
 /*
  * Interrupt current command

--- a/library/twopence.h
+++ b/library/twopence.h
@@ -33,7 +33,12 @@ struct pollfd;
 #define TWOPENCE_API_MAJOR_VERSION	0
 #define TWOPENCE_API_MINOR_VERSION	3
 
-/* Error codes */
+/*
+ * Error codes.
+ * Note: if you define new error codes, make sure you extend
+ * twopence_strerror(), and define a symbolic constant in
+ * the python module (ie twopence.FOOBAR_ERROR).
+ */
 #define TWOPENCE_PARAMETER_ERROR		-1
 #define TWOPENCE_OPEN_SESSION_ERROR		-2
 #define TWOPENCE_SEND_COMMAND_ERROR		-3

--- a/library/twopence.h
+++ b/library/twopence.h
@@ -54,6 +54,7 @@ struct pollfd;
 #define TWOPENCE_TRANSPORT_ERROR		-18
 #define TWOPENCE_INCOMPATIBLE_PROTOCOL_ERROR	-19
 #define TWOPENCE_INVALID_TRANSACTION		-20
+#define TWOPENCE_COMMAND_CANCELED_ERROR		-21
 
 typedef struct twopence_target twopence_target_t;
 
@@ -99,6 +100,7 @@ struct twopence_plugin {
 	int			(*extract_file)(struct twopence_target *, twopence_file_xfer_t *, twopence_status_t *);
 	int			(*exit_remote)(struct twopence_target *);
 	int			(*interrupt_command)(struct twopence_target *);
+	int			(*cancel_transactions)(twopence_target_t *);
 	int			(*disconnect)(twopence_target_t *);
 	void			(*end)(struct twopence_target *);
 };
@@ -515,6 +517,17 @@ extern int		twopence_recv_file(struct twopence_target *target,
  *   Returns 0 if everything went fine.
  */
 extern int		twopence_exit_remote(struct twopence_target *target);
+
+/*
+ * Cancel all pending transactions with a status of TWOPENCE_COMMAND_CANCELED_ERROR
+ *
+ * Input:
+ *   handle: the handle returned by the initialization function
+ *
+ * Output:
+ *   Returns 0 if everything went fine.
+ */
+extern int		twopence_cancel_transactions(twopence_target_t *target);
 
 /*
  * Disconnect from the SUT, and cancel all pending transactions.

--- a/library/twopence.h
+++ b/library/twopence.h
@@ -64,6 +64,9 @@ typedef struct twopence_target twopence_target_t;
  *		indicating any issues encountered while executing
  *		the command.
  * minor:	this is the exit status of the command itself.
+ * pid:		the pid of the command. This is mostly useful
+ *		when wait() returns an error, and you wish to
+ *		know which command errored out.
  *
  * FIXME: we should dissect the status code on the SUT rather than
  * the system running twopence, as the exit code, signal information
@@ -75,6 +78,7 @@ typedef struct twopence_target twopence_target_t;
 typedef struct twopence_status {
 	int			major;
 	int			minor;
+	int			pid;
 } twopence_status_t;
 
 /* Forward decls for the plugin functions */

--- a/library/utils.h
+++ b/library/utils.h
@@ -36,6 +36,10 @@ typedef struct twopence_pollinfo {
 	twopence_timeout_t	timeout;
 } twopence_pollinfo_t;
 
+typedef struct twopence_timer_list {
+	struct twopence_timer *		head;
+} twopence_timer_list_t;
+
 extern void		twopence_timeout_init(twopence_timeout_t *);
 extern bool		twopence_timeout_update(twopence_timeout_t *, const struct timeval *deadline);
 extern long		twopence_timeout_msec(const twopence_timeout_t *);
@@ -52,5 +56,15 @@ extern void *		twopence_realloc(void *p, size_t size);
 extern void *		twopence_calloc(size_t nmemb, size_t size);
 extern char *		twopence_strdup(const char *s);
 extern void		twopence_strfree(char **sp);
+
+extern void		twopence_timer_list_insert(twopence_timer_list_t *list, struct twopence_timer *timer);
+extern void		twopence_timer_list_update_timeout(twopence_timer_list_t *, twopence_timeout_t *);
+extern void		twopence_timer_list_expire(twopence_timer_list_t *list);
+extern void		twopence_timer_list_reap(twopence_timer_list_t *list, twopence_timer_list_t *expired);
+extern void		twopence_timer_list_invoke(twopence_timer_list_t *list);
+extern void		twopence_timer_list_destroy(twopence_timer_list_t *list);
+
+extern void		twopence_timers_update_timeout(twopence_timeout_t *tmo);
+extern void		twopence_timers_run(void);
 
 #endif /* UTILS_H */

--- a/library/virtio.c
+++ b/library/virtio.c
@@ -135,5 +135,6 @@ const struct twopence_plugin twopence_virtio_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/library/virtio.c
+++ b/library/virtio.c
@@ -135,6 +135,7 @@ const struct twopence_plugin twopence_virtio_ops = {
 	.extract_file = twopence_pipe_extract_file,
 	.exit_remote = twopence_pipe_exit_remote,
 	.interrupt_command = twopence_pipe_interrupt_command,
+	.cancel_transactions = twopence_pipe_cancel_transactions,
 	.disconnect = twopence_pipe_disconnect,
 	.end = twopence_pipe_end,
 };

--- a/python/Makefile
+++ b/python/Makefile
@@ -27,6 +27,7 @@ OBJS	= extension.o \
 	  transfer.o \
 	  status.o \
 	  chat.o \
+	  timer.o \
 	  target.o
 
 all: twopence.so

--- a/python/extension.c
+++ b/python/extension.c
@@ -117,4 +117,5 @@ inittwopence(void)
 	twopence_registerType(m, "Transfer", &twopence_TransferType);
 	twopence_registerType(m, "Status", &twopence_StatusType);
 	twopence_registerType(m, "Chat", &twopence_ChatType);
+	twopence_registerType(m, "Timer", &twopence_TimerType);
 }

--- a/python/extension.c
+++ b/python/extension.c
@@ -84,19 +84,25 @@ twopence_registerType(PyObject *m, const char *name, PyTypeObject *type)
 }
 
 PyObject *
-twopence_callType(PyTypeObject *typeObject, PyObject *args, PyObject *kwds)
+twopence_callObject(PyObject *callable, PyObject *args, PyObject *kwds)
 {
 	PyObject *obj;
 
 	if (args == NULL) {
 		args = PyTuple_New(0);
-		obj = PyObject_Call((PyObject *) typeObject, args, NULL);
+		obj = PyObject_Call(callable, args, NULL);
 		Py_DECREF(args);
 	} else {
-		obj = PyObject_Call((PyObject *) typeObject, args, kwds);
+		obj = PyObject_Call(callable, args, kwds);
 	}
 
 	return obj;
+}
+
+PyObject *
+twopence_callType(PyTypeObject *typeObject, PyObject *args, PyObject *kwds)
+{
+	return twopence_callObject((PyObject *) typeObject, args, kwds);
 }
 
 PyMODINIT_FUNC

--- a/python/extension.c
+++ b/python/extension.c
@@ -83,6 +83,46 @@ twopence_registerType(PyObject *m, const char *name, PyTypeObject *type)
 	PyModule_AddObject(m, name, (PyObject *) type);
 }
 
+#define DECLARE_ERROR(x) \
+	{ TWOPENCE_##x, #x }
+
+static void
+twopence_registerErrorConstants(PyObject *m)
+{
+	struct map {
+		int		code;
+		const char *	name;
+	};
+	struct map errorMap[] = {
+		DECLARE_ERROR(PARAMETER_ERROR),
+		DECLARE_ERROR(OPEN_SESSION_ERROR),
+		DECLARE_ERROR(SEND_COMMAND_ERROR),
+		DECLARE_ERROR(FORWARD_INPUT_ERROR),
+		DECLARE_ERROR(RECEIVE_RESULTS_ERROR),
+		DECLARE_ERROR(COMMAND_TIMEOUT_ERROR),
+		DECLARE_ERROR(LOCAL_FILE_ERROR),
+		DECLARE_ERROR(SEND_FILE_ERROR),
+		DECLARE_ERROR(REMOTE_FILE_ERROR),
+		DECLARE_ERROR(RECEIVE_FILE_ERROR),
+		DECLARE_ERROR(INTERRUPT_COMMAND_ERROR),
+		DECLARE_ERROR(INVALID_TARGET_ERROR),
+		DECLARE_ERROR(UNKNOWN_PLUGIN_ERROR),
+		DECLARE_ERROR(INCOMPATIBLE_PLUGIN_ERROR),
+		DECLARE_ERROR(UNSUPPORTED_FUNCTION_ERROR),
+		DECLARE_ERROR(PROTOCOL_ERROR),
+		DECLARE_ERROR(INTERNAL_ERROR),
+		DECLARE_ERROR(TRANSPORT_ERROR),
+		DECLARE_ERROR(INCOMPATIBLE_PROTOCOL_ERROR),
+		DECLARE_ERROR(INVALID_TRANSACTION),
+		DECLARE_ERROR(COMMAND_CANCELED_ERROR),
+		{ -1, NULL }
+	};
+	struct map *em;
+
+	for (em = errorMap; em->name; ++em)
+		PyModule_AddIntConstant(m, em->name, -em->code);
+}
+
 PyObject *
 twopence_callObject(PyObject *callable, PyObject *args, PyObject *kwds)
 {
@@ -118,4 +158,6 @@ inittwopence(void)
 	twopence_registerType(m, "Status", &twopence_StatusType);
 	twopence_registerType(m, "Chat", &twopence_ChatType);
 	twopence_registerType(m, "Timer", &twopence_TimerType);
+
+	twopence_registerErrorConstants(m);
 }

--- a/python/extension.h
+++ b/python/extension.h
@@ -116,6 +116,7 @@ extern int		Transfer_Check(PyObject *);
 extern int		Transfer_build_send(twopence_Transfer *, twopence_file_xfer_t *);
 extern int		Transfer_build_recv(twopence_Transfer *, twopence_file_xfer_t *);
 extern PyObject *	twopence_Exception(const char *msg, int rc);
+extern PyObject *	twopence_callObject(PyObject *callable, PyObject *args, PyObject *kwds);
 extern PyObject *	twopence_callType(PyTypeObject *typeObject, PyObject *args, PyObject *kwds);
 extern int		twopence_AppendBuffer(PyObject *buffer, const twopence_buf_t *buf);
 

--- a/python/extension.h
+++ b/python/extension.h
@@ -82,6 +82,9 @@ typedef struct {
 	PyObject_HEAD
 
 	int		remoteStatus;
+	int		localError;
+	int		exitSignal;
+
 	/* for cmd operations */
 	PyObject *	stdout;
 	PyObject *	stderr;

--- a/python/extension.h
+++ b/python/extension.h
@@ -50,6 +50,7 @@ typedef struct {
 	PyObject *	stdin;
 	bool		useTty;
 	bool		background;
+	bool		softfail;
 
 	twopence_env_t	environ;
 

--- a/python/extension.h
+++ b/python/extension.h
@@ -99,6 +99,13 @@ typedef struct {
 	unsigned int	pid;
 } twopence_Chat;
 
+typedef struct {
+	PyObject_HEAD
+
+	twopence_timer_t *timer;
+	PyObject *	callback;
+} twopence_Timer;
+
 
 
 extern PyTypeObject	twopence_TargetType;
@@ -106,6 +113,7 @@ extern PyTypeObject	twopence_CommandType;
 extern PyTypeObject	twopence_TransferType;
 extern PyTypeObject	twopence_StatusType;
 extern PyTypeObject	twopence_ChatType;
+extern PyTypeObject	twopence_TimerType;
 
 extern int		Command_init(twopence_Command *self, PyObject *args, PyObject *kwds);
 extern int		Command_Check(PyObject *);

--- a/python/status.c
+++ b/python/status.c
@@ -30,6 +30,9 @@ static PyObject *	Status_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 static int		Status_init(twopence_Status *self, PyObject *args, PyObject *kwds);
 static PyObject *	Status_getattr(twopence_Status *self, char *name);
 static int		Status_nonzero(twopence_Status *);
+static int		Status_code(const twopence_Status *self);
+static int		Status_nameToSignal(const char *);
+static const char *	Status_signalToName(int signal);
 
 /*
  * Define the python bindings of class "Status"
@@ -75,6 +78,9 @@ Status_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
 	/* init members */
 	self->remoteStatus = 0;
+	self->localError = 0;
+	self->exitSignal = 0;
+
 	self->stdout = NULL;
 	self->stderr = NULL;
 	self->command = NULL;
@@ -93,18 +99,32 @@ Status_init(twopence_Status *self, PyObject *args, PyObject *kwds)
 		"status",
 		"stdout",
 		"stderr",
+		"error",
+		"signal",
 		NULL
 	};
 	PyObject *stdoutObject = NULL, *stderrObject = NULL;
-	int exitval = 0;
+	const char *signalName = NULL;
+	int exitval = 0, error = 0, signal = 0;
 
 	if (args == Py_None)
 		return 0;
 
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iOO", kwlist, &exitval, &stdoutObject, &stderrObject))
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iOOis", kwlist,
+				&exitval, &stdoutObject, &stderrObject, &error, &signal))
 		return -1;
 
+	if (signalName) {
+		signal = Status_nameToSignal(signalName);
+		if (signal < 0) {
+			PyErr_Format(PyExc_ValueError, "bad signal name \"%s\"", signalName);
+			return -1;
+		}
+	}
+
 	self->remoteStatus = exitval;
+	self->localError = error;
+	self->exitSignal = signal;
 	self->stdout = NULL;
 	self->stderr = NULL;
 	self->buffer = NULL;
@@ -151,17 +171,17 @@ Status_object_attr(twopence_Status *self, PyObject *result)
 static PyObject *
 Status_message(twopence_Status *self)
 {
-	int st = self->remoteStatus;
 	char message[128];
 
 	message[0] = '\0';
 
-	if (st == 0) {
+	if (self->exitSignal) {
+		snprintf(message, sizeof(message), "crashed (received signal %s)",
+				Status_signalToName(self->exitSignal));
+	} else if (self->localError) {
+		snprintf(message, sizeof(message), "local error: %s", twopence_strerror(self->localError));
+	} else if (self->remoteStatus == 0) {
 		strcpy(message, "success");
-	} else if (st & 0x100) {
-		snprintf(message, sizeof(message), "crashed (signal %u)", st & 0xFF);
-	} else if (st & 0x200) {
-		snprintf(message, sizeof(message), "local error: %s", twopence_strerror(-(st & 0xFF)));
 	} else {
 		snprintf(message, sizeof(message), "status %d", self->remoteStatus);
 	}
@@ -179,7 +199,18 @@ Status_getattr(twopence_Status *self, char *name)
 	if (!strcmp(name, "buffer"))
 		return Status_object_attr(self, self->buffer);
 	if (!strcmp(name, "code"))
+		return PyInt_FromLong(Status_code(self));
+	if (!strcmp(name, "localError"))
+		return PyInt_FromLong(-self->localError);
+	if (!strcmp(name, "exitStatus"))
 		return PyInt_FromLong(self->remoteStatus);
+	if (!strcmp(name, "exitSignal")) {
+		if (self->exitSignal == 0) {
+			Py_INCREF(Py_None);
+			return Py_None;
+		}
+		return PyString_FromString(Status_signalToName(self->exitSignal));
+	}
 	if (!strcmp(name, "command")) {
 		PyObject *result = self->command;
 
@@ -206,5 +237,75 @@ Status_getattr(twopence_Status *self, char *name)
 static int
 Status_nonzero(twopence_Status *self)
 {
-	return self->remoteStatus == 0;
+	return (self->remoteStatus | self->localError | self->exitSignal) == 0;
+}
+
+static int
+Status_code(const twopence_Status *self)
+{
+	if (self->exitSignal)
+		return 0x100 | self->exitSignal;
+	if (self->localError)
+		return 0x200 | self->localError;
+	return self->remoteStatus;
+}
+
+/*
+ * Signal to name mapping
+ */
+#define SIG(NAME)	{ .no = SIG##NAME, .name = #NAME }, \
+			{ .no = SIG##NAME, .name = "SIG" #NAME }
+
+static struct signal_name {
+	int no;
+	const char *name;
+} signal_names[] = {
+	SIG(HUP),
+	SIG(INT),
+	SIG(QUIT),
+	SIG(ILL),
+	SIG(ABRT),
+	SIG(FPE),
+	SIG(KILL),
+	SIG(SEGV),
+	SIG(ALRM),
+	SIG(PIPE),
+	SIG(TERM),
+	SIG(USR1),
+	SIG(USR2),
+	SIG(CHLD),
+	SIG(BUS),
+	{ 0, NULL }
+};
+
+
+static int
+Status_nameToSignal(const char *name)
+{
+	struct signal_name *n;
+
+	for (n = signal_names; n->name; ++n) {
+		if (!strcasecmp(n->name, name))
+			return n->no;
+	}
+
+	return -1;
+}
+
+static const char *
+Status_signalToName(int signal)
+{
+	static char namebuf[16];
+	struct signal_name *n;
+
+	if (signal == 0)
+		return "none";
+
+	for (n = signal_names; n->name; ++n) {
+		if (n->no == signal)
+			return n->name;
+	}
+
+	snprintf(namebuf, sizeof(namebuf), "SIG%u", signal);
+	return namebuf;
 }

--- a/python/status.c
+++ b/python/status.c
@@ -160,6 +160,8 @@ Status_message(twopence_Status *self)
 		strcpy(message, "success");
 	} else if (st & 0x100) {
 		snprintf(message, sizeof(message), "crashed (signal %u)", st & 0xFF);
+	} else if (st & 0x200) {
+		snprintf(message, sizeof(message), "local error: %s", twopence_strerror(-(st & 0xFF)));
 	} else {
 		snprintf(message, sizeof(message), "status %d", self->remoteStatus);
 	}

--- a/python/target.c
+++ b/python/target.c
@@ -41,6 +41,7 @@ static PyObject *	Target_recvfile(twopence_Target *self, PyObject *args, PyObjec
 static PyObject *	Target_setenv(twopence_Target *, PyObject *, PyObject *);
 static PyObject *	Target_unsetenv(twopence_Target *, PyObject *, PyObject *);
 static PyObject *	Target_disconnect(twopence_Target *, PyObject *, PyObject *);
+static PyObject *	Target_cancel_transactions(twopence_Target *, PyObject *, PyObject *);
 static PyObject *	Target_chat(twopence_Target *, PyObject *, PyObject *);
 
 /*
@@ -91,6 +92,9 @@ static PyMethodDef twopence_targetMethods[] = {
       },
       {	"disconnect", (PyCFunction) Target_disconnect, METH_VARARGS | METH_KEYWORDS,
 	"Close the connection to the target"
+      },
+      {	"cancel_transactions", (PyCFunction) Target_cancel_transactions, METH_VARARGS | METH_KEYWORDS,
+	"Cancel all pending transactions"
       },
 
       {	NULL }
@@ -898,6 +902,23 @@ Target_disconnect(twopence_Target *self, PyObject *args, PyObject *kwds)
 
 	if (self->handle != NULL)
 		twopence_disconnect(self->handle);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+static PyObject *
+Target_cancel_transactions(twopence_Target *self, PyObject *args, PyObject *kwds)
+{
+	static char *kwlist[] = {
+		NULL
+	};
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "", kwlist))
+		return NULL;
+
+	if (self->handle != NULL)
+		twopence_cancel_transactions(self->handle);
 
 	Py_INCREF(Py_None);
 	return Py_None;

--- a/python/target.c
+++ b/python/target.c
@@ -40,6 +40,7 @@ static PyObject *	Target_sendfile(twopence_Target *self, PyObject *args, PyObjec
 static PyObject *	Target_recvfile(twopence_Target *self, PyObject *args, PyObject *kwds);
 static PyObject *	Target_setenv(twopence_Target *, PyObject *, PyObject *);
 static PyObject *	Target_unsetenv(twopence_Target *, PyObject *, PyObject *);
+static PyObject *	Target_disconnect(twopence_Target *, PyObject *, PyObject *);
 static PyObject *	Target_chat(twopence_Target *, PyObject *, PyObject *);
 
 /*
@@ -87,6 +88,9 @@ static PyMethodDef twopence_targetMethods[] = {
       },
       {	"chat", (PyCFunction) Target_chat, METH_VARARGS | METH_KEYWORDS,
 	"Create a Chat object for the given command"
+      },
+      {	"disconnect", (PyCFunction) Target_disconnect, METH_VARARGS | METH_KEYWORDS,
+	"Close the connection to the target"
       },
 
       {	NULL }
@@ -877,6 +881,23 @@ Target_unsetenv(twopence_Target *self, PyObject *args, PyObject *kwds)
 		return NULL;
 
 	twopence_target_setenv(self->handle, variable, NULL);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+static PyObject *
+Target_disconnect(twopence_Target *self, PyObject *args, PyObject *kwds)
+{
+	static char *kwlist[] = {
+		NULL
+	};
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "", kwlist))
+		return NULL;
+
+	if (self->handle != NULL)
+		twopence_disconnect(self->handle);
 
 	Py_INCREF(Py_None);
 	return Py_None;

--- a/python/target.c
+++ b/python/target.c
@@ -30,17 +30,17 @@ static void		Target_dealloc(twopence_Target *self);
 static PyObject *	Target_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 static int		Target_init(twopence_Target *self, PyObject *args, PyObject *kwds);
 static PyObject *	Target_getattr(twopence_Target *self, char *name);
-static PyObject *	Target_run(PyObject *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_wait(PyObject *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_waitAll(PyObject *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_run(twopence_Target *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_wait(twopence_Target *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_waitAll(twopence_Target *self, PyObject *args, PyObject *kwds);
 static PyObject *	Target_property(twopence_Target *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_inject(PyObject *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_extract(PyObject *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_sendfile(PyObject *self, PyObject *args, PyObject *kwds);
-static PyObject *	Target_recvfile(PyObject *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_inject(twopence_Target *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_extract(twopence_Target *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_sendfile(twopence_Target *self, PyObject *args, PyObject *kwds);
+static PyObject *	Target_recvfile(twopence_Target *self, PyObject *args, PyObject *kwds);
 static PyObject *	Target_setenv(twopence_Target *, PyObject *, PyObject *);
 static PyObject *	Target_unsetenv(twopence_Target *, PyObject *, PyObject *);
-static PyObject *	Target_chat(PyObject *, PyObject *, PyObject *);
+static PyObject *	Target_chat(twopence_Target *, PyObject *, PyObject *);
 
 /*
  * Define the python bindings of class "Target"
@@ -166,16 +166,6 @@ Target_dealloc(twopence_Target *self)
 	self->handle = NULL;
 
 	drop_object(&self->attrs);
-}
-
-/*
- * Extract twopence target handle from python object.
- * This should really do a type check and throw an exception if it doesn't match
- */
-static struct twopence_target *
-Target_handle(PyObject *self)
-{
-	return ((twopence_Target *) self)->handle;
 }
 
 static PyObject *
@@ -362,7 +352,7 @@ Target_buildCommandStatusShort(twopence_Command *cmdObject, twopence_command_t *
  * To suppress all output, pass "none" objects to 'stdout' und 'stderr'.
  */
 static PyObject *
-Target_run(PyObject *self, PyObject *args, PyObject *kwds)
+Target_run(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	struct twopence_target *handle;
 	twopence_Command *cmdObject = NULL;
@@ -395,8 +385,7 @@ Target_run(PyObject *self, PyObject *args, PyObject *kwds)
 		goto out;
 	}
 
-	if ((handle = Target_handle(self)) == NULL)
-		goto out;
+	handle = self->handle;
 
 	memset(&cmd, 0, sizeof(cmd));
 	if (cmdObject->background) {
@@ -486,13 +475,12 @@ Target_wait_common(twopence_Target *tgtObject, int pid)
 }
 
 static PyObject *
-Target_wait(PyObject *self, PyObject *args, PyObject *kwds)
+Target_wait(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	static char *kwlist[] = {
 		"command",
 		NULL
 	};
-	twopence_Target *tgtObject = (twopence_Target *) self;
 	PyObject *argObject = NULL;
 	int pid = 0;
 
@@ -521,28 +509,24 @@ Target_wait(PyObject *self, PyObject *args, PyObject *kwds)
 		return NULL;
 	}
 
-	return Target_wait_common(tgtObject, pid);
+	return Target_wait_common(self, pid);
 }
 
 /*
  * Wait for all commands to complete
  */
 static PyObject *
-Target_waitAll(PyObject *self, PyObject *args, PyObject *kwds)
+Target_waitAll(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	static char *kwlist[] = {
 		"print_dots",
 		NULL
 	};
-	twopence_target_t *handle;
-	twopence_Target *tgtObject = (twopence_Target *) self;
+	twopence_target_t *handle = self->handle;
 	twopence_Status *result = NULL;
 	int print_dots = 0, ndots = 0;
 
 	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|i", kwlist, &print_dots))
-		return NULL;
-
-	if ((handle = Target_handle(self)) == NULL)
 		return NULL;
 
 	while (true) {
@@ -563,7 +547,7 @@ Target_waitAll(PyObject *self, PyObject *args, PyObject *kwds)
 			break;
 		}
 
-		bg = Target_findBackgrounded(tgtObject, pid);
+		bg = Target_findBackgrounded(self, pid);
 		if (bg == NULL) {
 			if (ndots)
 				printf("\n");
@@ -597,7 +581,7 @@ Target_waitAll(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyObject *
-Target_chat(PyObject *self, PyObject *args, PyObject *kwds)
+Target_chat(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	twopence_Target *tgtObject = (twopence_Target *) self;
 	twopence_Command *cmdObject = NULL;
@@ -684,7 +668,7 @@ failed:
  * inject file into SUT
  */
 static PyObject *
-Target_inject(PyObject *self, PyObject *args, PyObject *kwds)
+Target_inject(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	static char *kwlist[] = {
 		"local",
@@ -693,7 +677,7 @@ Target_inject(PyObject *self, PyObject *args, PyObject *kwds)
 		"mode",
 		NULL
 	};
-	struct twopence_target *handle;
+	struct twopence_target *handle = self->handle;
 	char *sourceFile, *destFile;
 	char *user = "root";
 	int omode = 0644;
@@ -703,10 +687,6 @@ Target_inject(PyObject *self, PyObject *args, PyObject *kwds)
 		return NULL;
 
 	/* printf("inject %s -> %s (user %s, mode 0%o)\n", sourceFile, destFile, user, omode); */
-
-	if ((handle = Target_handle(self)) == NULL)
-		return NULL;
-
 	rc = twopence_inject_file(handle, user, sourceFile, destFile, &remoteRc, 0);
 	if (rc < 0)
 		return twopence_Exception("inject", rc);
@@ -718,7 +698,7 @@ Target_inject(PyObject *self, PyObject *args, PyObject *kwds)
  * extract file from SUT
  */
 static PyObject *
-Target_extract(PyObject *self, PyObject *args, PyObject *kwds)
+Target_extract(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
 	static char *kwlist[] = {
 		"local",
@@ -727,7 +707,7 @@ Target_extract(PyObject *self, PyObject *args, PyObject *kwds)
 		"mode",
 		NULL
 	};
-	struct twopence_target *handle;
+	struct twopence_target *handle = self->handle;
 	char *sourceFile, *destFile;
 	char *user = "root";
 	int omode = 0644;
@@ -737,9 +717,6 @@ Target_extract(PyObject *self, PyObject *args, PyObject *kwds)
 		return NULL;
 
 	/* printf("extract %s -> %s (user %s, mode 0%o)\n", sourceFile, destFile, user, omode); */
-	if ((handle = Target_handle(self)) == NULL)
-		return NULL;
-
 	rc = twopence_extract_file(handle, user, sourceFile, destFile, &remoteRc, 0);
 	if (rc < 0)
 		return twopence_Exception("extract", rc);
@@ -776,9 +753,9 @@ Taget_send_recv_common(PyObject *args, PyObject *kwds)
  * transfer a file to the SUT
  */
 static PyObject *
-Target_sendfile(PyObject *self, PyObject *args, PyObject *kwds)
+Target_sendfile(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
-	struct twopence_target *handle;
+	struct twopence_target *handle = self->handle;
 	twopence_Transfer *xferObject = NULL;
 	twopence_Status *statusObject;
 	twopence_file_xfer_t xfer;
@@ -794,9 +771,6 @@ Target_sendfile(PyObject *self, PyObject *args, PyObject *kwds)
 
 	if (Transfer_build_send(xferObject, &xfer) < 0)
 		goto out;
-
-	if ((handle = Target_handle(self)) == NULL)
-		return NULL;
 
 	rc = twopence_send_file(handle, &xfer, &status);
 	if (rc < 0) {
@@ -821,9 +795,9 @@ out:
  * transfer a file to the SUT
  */
 static PyObject *
-Target_recvfile(PyObject *self, PyObject *args, PyObject *kwds)
+Target_recvfile(twopence_Target *self, PyObject *args, PyObject *kwds)
 {
-	struct twopence_target *handle;
+	struct twopence_target *handle = self->handle;
 	twopence_Transfer *xferObject = NULL;
 	twopence_Status *statusObject;
 	twopence_file_xfer_t xfer;
@@ -839,9 +813,6 @@ Target_recvfile(PyObject *self, PyObject *args, PyObject *kwds)
 
 	if (Transfer_build_recv(xferObject, &xfer) < 0)
 		goto out;
-
-	if ((handle = Target_handle(self)) == NULL)
-		return NULL;
 
 	rc = twopence_recv_file(handle, &xfer, &status);
 	if (rc < 0) {

--- a/python/timer.c
+++ b/python/timer.c
@@ -1,0 +1,316 @@
+/*
+Twopence python bindings - class Timer
+
+Copyright (C) 2016 SUSE
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 2.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+
+#include "extension.h"
+
+#include <fcntl.h>
+#include <sys/wait.h>
+
+#include "twopence.h"
+
+static void		Timer_dealloc(twopence_Timer *self);
+static PyObject *	Timer_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
+static int		Timer_init(twopence_Timer *self, PyObject *args, PyObject *kwds);
+static PyObject *	Timer_getattr(twopence_Timer *self, char *name);
+static int		Timer_setattr(twopence_Timer *self, char *name, PyObject *);
+static PyObject *	Timer_pause(twopence_Timer *, PyObject *, PyObject *);
+static PyObject *	Timer_unpause(twopence_Timer *, PyObject *, PyObject *);
+static PyObject *	Timer_cancel(twopence_Timer *, PyObject *, PyObject *);
+static void		__Timer_callback(twopence_timer_t *t, void *user_data);
+
+/*
+ * Define the python bindings of class "Timer"
+ * Normally, you do not create Timer objects yourself;
+ * Usually, these are created as the return value of Target.addtimer()
+ */
+static PyMethodDef twopence_timerMethods[] = {
+      {	"cancel", (PyCFunction) Timer_cancel, METH_VARARGS | METH_KEYWORDS,
+	"Cancel the timer"
+      },
+      {	"pause", (PyCFunction) Timer_pause, METH_VARARGS | METH_KEYWORDS,
+	"Pause the timer"
+      },
+      {	"unpause", (PyCFunction) Timer_unpause, METH_VARARGS | METH_KEYWORDS,
+	"Unpause the timer"
+      },
+      {	NULL }
+};
+
+PyTypeObject twopence_TimerType = {
+	PyObject_HEAD_INIT(NULL)
+
+	.tp_name	= "twopence.Timer",
+	.tp_basicsize	= sizeof(twopence_Timer),
+	.tp_flags	= Py_TPFLAGS_DEFAULT,
+	.tp_doc		= "Twopence timer",
+
+	.tp_methods	= twopence_timerMethods,
+	.tp_init	= (initproc) Timer_init,
+	.tp_new		= Timer_new,
+	.tp_dealloc	= (destructor) Timer_dealloc,
+
+	.tp_getattr	= (getattrfunc) Timer_getattr,
+	.tp_setattr	= (setattrfunc) Timer_setattr,
+};
+
+/*
+ * Constructor: allocate empty Timer object, and set its members.
+ */
+static PyObject *
+Timer_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+	twopence_Timer *self;
+
+	self = (twopence_Timer *) type->tp_alloc(type, 0);
+	if (self == NULL)
+		return NULL;
+
+	/* init members */
+	self->timer = NULL;
+	self->callback = NULL;
+
+	return (PyObject *)self;
+}
+
+/*
+ * Initialize the status object
+ */
+static int
+Timer_init(twopence_Timer *self, PyObject *args, PyObject *kwds)
+{
+	static char *kwlist[] = {
+		"timeout",
+		"callback",
+		NULL
+	};
+	PyObject *callbackObj = NULL;
+	twopence_timer_t *timer;
+	double timeout;
+	int rc;
+
+
+	if (args == Py_None)
+		return 0;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "d|O", kwlist, &timeout, &callbackObj))
+		return -1;
+
+	if (timeout <= 0) {
+		/* FIXME: raise ValueError exception */
+		return -1;
+	}
+
+	if ((rc = twopence_timer_create(timeout * 1000, &timer)) < 0) {
+		twopence_Exception("failed to create timer", rc);
+		return -1;
+	}
+
+	twopence_timer_hold(timer);
+	self->timer = timer;
+
+	if (callbackObj == NULL)
+		assign_object(&self->callback, Py_None);
+	else
+		assign_object(&self->callback, callbackObj);
+
+	twopence_timer_set_callback(timer, __Timer_callback, self);
+
+	return 0;
+}
+
+/*
+ * This callback gets invoked from the lower-level twopence library
+ * when the timer fires.
+ */
+static void
+__Timer_callback(twopence_timer_t *t, void *user_data)
+{
+	twopence_Timer *timerObj = (twopence_Timer *) user_data;
+	PyObject *v;
+
+	if (timerObj->callback == NULL || timerObj->callback == Py_None) {
+		twopence_debug("Timer %u fired; no python callback set", t->id);
+		return;
+	}
+
+	twopence_debug("Timer %u fired; invoking python callback", t->id);
+	v = twopence_callObject(timerObj->callback, NULL, NULL);
+	if (v == NULL) {
+		twopence_log_error("Exception in twopence.Timer callback");
+	} else {
+		/* We don't care what it returned, we just need to dispose of it */
+		Py_DECREF(v);
+	}
+}
+
+/*
+ * Destructor: clean any state inside the Timer object
+ */
+static void
+Timer_dealloc(twopence_Timer *self)
+{
+	if (self->timer)
+		twopence_timer_release(self->timer);
+	self->timer = NULL;
+
+	drop_object(&self->callback);
+}
+
+int
+Timer_Check(PyObject *self)
+{
+	return PyType_IsSubtype(Py_TYPE(self), &twopence_TimerType);
+}
+
+static twopence_timer_t *
+Timer_handle(twopence_Timer *self)
+{
+	if (self->timer)
+		return self->timer;
+
+	PyErr_SetString(PyExc_ValueError, "Timer object without handle");
+	return NULL;
+}
+
+const char *
+Timer_state2name(int state)
+{
+	switch (state) {
+	case TWOPENCE_TIMER_STATE_ACTIVE:
+		return "active";
+	case TWOPENCE_TIMER_STATE_PAUSED:
+		return "paused";
+	case TWOPENCE_TIMER_STATE_CANCELLED:
+		return "cancelled";
+	case TWOPENCE_TIMER_STATE_EXPIRED:
+	case TWOPENCE_TIMER_STATE_DEAD:
+		return "expired";
+	}
+	return "unknown";
+}
+
+static PyObject *
+Timer_getattr(twopence_Timer *self, char *name)
+{
+	if (!strcmp(name, "callback")
+	 || !strcmp(name, "state")
+	 || !strcmp(name, "remaining")
+	 || !strcmp(name, "id")) {
+		twopence_timer_t *timer;
+
+		if (!(timer = Timer_handle(self)))
+			return NULL;
+
+		if (!strcmp(name, "callback")) {
+			Py_INCREF(self->callback);
+			return self->callback;
+		}
+		if (!strcmp(name, "state"))
+			return PyString_FromString(Timer_state2name(timer->state));
+		if (!strcmp(name, "id"))
+			return PyInt_FromLong(timer->id);
+		if (!strcmp(name, "remaining"))
+			return PyFloat_FromDouble(twopence_timer_remaining(timer) * 1e-3);
+	}
+
+	return Py_FindMethod(twopence_timerMethods, (PyObject *) self, name);
+}
+
+static int
+Timer_setattr(twopence_Timer *self, char *name, PyObject *v)
+{
+	twopence_timer_t *timer;
+
+	if (!(timer = Timer_handle(self)))
+		return -1;
+
+	if (timer->state != TWOPENCE_TIMER_STATE_ACTIVE
+	 && timer->state != TWOPENCE_TIMER_STATE_PAUSED)
+		goto bad_expired;
+
+	if (!strcmp(name, "callback")) {
+		assign_object(&self->callback, v);
+		return 0;
+	}
+
+	(void) PyErr_Format(PyExc_AttributeError, "Unknown attribute: %s", name);
+	return -1;
+
+bad_expired:
+	(void) PyErr_Format(PyExc_AttributeError, "Cannot set attribute: %s in expired timer", name);
+	return -1;
+}
+
+static PyObject *
+Timer_cancel(twopence_Timer *self, PyObject *args, PyObject *kwds)
+{
+	static char *kwlist[] = {
+		NULL
+	};
+	twopence_timer_t *timer;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "", kwlist))
+		return NULL;
+
+	if (!(timer = Timer_handle(self)))
+		return NULL;
+
+	twopence_timer_cancel(timer);
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+static PyObject *
+Timer_pause(twopence_Timer *self, PyObject *args, PyObject *kwds)
+{
+	static char *kwlist[] = {
+		NULL
+	};
+	twopence_timer_t *timer;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "", kwlist))
+		return NULL;
+
+	if (!(timer = Timer_handle(self)))
+		return NULL;
+
+	twopence_timer_pause(timer);
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+static PyObject *
+Timer_unpause(twopence_Timer *self, PyObject *args, PyObject *kwds)
+{
+	static char *kwlist[] = {
+		NULL
+	};
+	twopence_timer_t *timer;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "", kwlist))
+		return NULL;
+
+	if (!(timer = Timer_handle(self)))
+		return NULL;
+
+	twopence_timer_unpause(timer);
+	Py_INCREF(Py_None);
+	return Py_None;
+}

--- a/python/twopence.3py
+++ b/python/twopence.3py
@@ -93,12 +93,13 @@ would look like this:
 .fi
 .P
 The \fBStatus\fP object returned by the \fBrun()\fP method carries several bits and pieces
-of information. The most important one being the remote exit status contained in
-\fBstatus.code\fP. If the command exited regularly, this will be the command's exit status.
-If the command died from a signal, its value will be 256 plus the termination signal
-(sorry, no translation of platform dependent signal numbers).
+of information. The most important one being the remote exit status reported by
+\fBstatus\fP. If the command exited regularly, \fBstatus.exitStatus\fP will be the
+command's exit status.
+If the command died from a signal, \fBstatus.exitSignal\fP will contain the
+name of the signal (\fBNone\fP otherwise).
 .P
-In order to allow for simple testing whether a command's exit status was zero, the
+In order to allow for simple testing whether a command exited cleanly with status of zero, the
 \fBStatus\fP class supports a built-in conversion to boolean, so that you can use it
 like this:
 .P
@@ -451,11 +452,21 @@ any such objects.
 .B code
 This is the status code of the remote command, or the status of the
 file transfer.
-If the remote command exited after receiving a signal, the status
+If the remote command was killed by a signal, the status
 code will be 256 plus the number of the termination signal.
 .TP
+.B localError
+If the command was run with \fBsoftfail\fP set to \fBTrue\fP, and
+a local error occurred, this attribute will contain the integer
+error code. Otherwise, this will be 0.
+.TP
+.B exitSignal
+If the command was killed by a signal, this will contain the
+name of the signal, such as \fB"HUP"\fP or \fB"TERM"\fP. Otherwise,
+this attribute returns \fBNone\fP.
+.TP
 .B message
-contains a descriptive message of the remote status, to be used
+contains a descriptive message of the status object, to be used
 in printing diagnostics. This is more of a convenience than really
 useful.
 .TP

--- a/python/twopence.3py
+++ b/python/twopence.3py
@@ -523,6 +523,52 @@ object's \fBstdout\fP and \fBstderr\fP objects is undefined.
 .\" --------------------------------------------------------------
 .\"
 .\"
+.SS Using timers
+.\" --------------------------------------------------------------
+In addition to setting a timeout value on individual commands, it is
+also possible to create global timers independent from a target. These
+can be created using the following contructor call:
+.TP
+.BI twopence.Timer( timeout "[, callback =" callable "])
+This will create a \fBTimer\fP object, setting its timeout to the specified
+number of seconds. The \fBtimeout\fP parameter is a double, so fractional
+values can be passed. The optional \fBcallback\fP parameter specifies the
+callback function that will be invoked upon expiration.
+.PP
+Note that the timer will be cancelled when the Timer object is deleted.
+.PP
+\fBTimer\fP objects currently support the following attributes and
+methods:
+.TP
+.BR state " (read-only)
+This describes the state the timer is currently in, which can be
+.BR active ,
+.BR paused ,
+.BR cancelled ", or
+.BR expired .
+.TP
+.BR callback " (read-write)
+This attribute holds a python callable.
+.TP
+.BR remaining " (read-only)
+This attribute returns a floating point value describing the
+remaining time (in seconds) until the timer expires.
+.TP
+.BR pause ()
+This will pause an active timer, and save the remaining time until it
+expires. For timers in a state other than \fBactive\fP, this operation
+will be a no-op.
+.TP
+.BR unpause ()
+This will resume a paused timer. The time of expiry will be adjusted to
+match the remaining time at the point where the timer was paused.
+For timers in a state other than \fBpaused\fP, this operation will be a no-op.
+.TP
+.BR cancel ()
+This will cancel an active timer. No action will be performed.
+.\" --------------------------------------------------------------
+.\"
+.\"
 .SS Twopence Exceptions
 .\" --------------------------------------------------------------
 For now, the twopence python bindings do not define their own

--- a/python/twopence.3py
+++ b/python/twopence.3py
@@ -228,6 +228,14 @@ Do not copy output to the python interpreter's stdout or stderr.
 Execute the command asynchronously. Running a command with \fBbackground\fP set to
 \fBTrue\fP will schedule the command for execution on the SUT and return immediately.
 For details, please refer to the section below.
+.TP
+.BR softfail " (read-write, constructor)
+By default, local errors (such as command timeout, or a broken connection)
+cause an exception to be raised. When setting the command's \fBsoftfail\fP
+attribute to \fBTrue\fP, these issues will be reported through a
+\fBStatus\fP object as usual.
+In this case, the \fBcode\fP attribute of the status object will be 512 + the
+twopence error code.
 .\" --------------------------------------------------------------
 .\"
 .\"

--- a/python/twopence.3py
+++ b/python/twopence.3py
@@ -42,6 +42,18 @@ Please do not use the \fBattrs\fP argument.
 .\" --------------------------------------------------------------
 .\"
 .\"
+.SS Target management methods
+.\" --------------------------------------------------------------
+The \fBTarget\fP class supports the following methods:
+.TP
+.BR disconnect ()
+This will cancel all pending transactions. Calling \fBwait()\fP
+on any of these will raise a transport error exception.
+The handle should be considered invalid afterwards, and should not
+be used afterwards for anything other than waiting for commands.
+.\" --------------------------------------------------------------
+.\"
+.\"
 .SS Target Object Attributes
 .\" --------------------------------------------------------------
 The target object supports these attributes:

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -1119,8 +1119,7 @@ try:
 	timer = twopence.Timer(2, callback = target.cancel_transactions)
 	status = target.run(cmd)
 
-	# Still a magic number here, not great
-	testCaseCheckLocalError(status, 21)
+	testCaseCheckLocalError(status, twopence.COMMAND_CANCELED_ERROR)
 except:
 	testCaseFail("Command should have soft-failed");
 	import traceback

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -705,7 +705,7 @@ else:
 testCaseReport()
 
 crossTargetConcurrencySupport = backgroundingSupported
-if target.type != "virtio" and target.type != "tcp" and target.type != "serial":
+if target.type not in ("virtio", "serial", "tcp", "chroot", "local"):
     crossTargetConcurrencySupport = False
 
 testCaseBegin("run concurrent processes on multiple targets")

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -1090,5 +1090,20 @@ except:
 	testCaseException()
 testCaseReport()
 
+testCaseBegin("Check whether we can cancel transactions")
+try:
+	cmd = twopence.Command("sleep 10", softfail = True)
+	timer = twopence.Timer(2, callback = target.cancel_transactions)
+	status = target.run(cmd)
+
+	testCaseCheckStatus(status, 512 + 21)
+except:
+	testCaseFail("Command should have soft-failed");
+	import traceback
+
+	print traceback.format_exc(None)
+
+testCaseReport()
+
 
 testSuiteExit()


### PR DESCRIPTION
This patchset, which sits on top of the other three I just submitted, adds the missing pieces
needed by twopence-ctcs2. twopence-ctcs2 is a first stab at a twopence-based executor of TCF
scripts, which I will submit to susetest in a moment.