### PR TITLE
Fixed bug: libssh might deliver less bytes than requested

### DIFF
--- a/library/ssh.c
+++ b/library/ssh.c
@@ -3,7 +3,7 @@ Test executor, ssh plugin.
 It is used to send tests to real machines or VMs using SSH protocol.
 
 
-Copyright (C) 2014-2015 SUSE
+Copyright (C) 2014-2020 SUSE
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -879,12 +879,14 @@ __twopence_ssh_receive_file(twopence_scp_transaction_t *trans, twopence_status_t
       size = BUFFER_SIZE;
 
     received = ssh_scp_read(trans->scp, buffer, size);
-    if (received != size)
+    if (received == SSH_ERROR)
     {
       status->major = ssh_get_error_code(trans->session);
       __twopence_ssh_putc(trans->dots_stream, '\n');
       return TWOPENCE_RECEIVE_FILE_ERROR;
     }
+    if (received != size)                     // libssh might deliver less than requested
+      size = received;
 
     written = twopence_iostream_write(trans->local_stream, buffer, size);
     if (written != size)

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -12,7 +12,7 @@ ifeq ($(UBUNTU),true)
   RBDIR      = $(LIBDIR)/ruby/$(RBVERSION)
 else
   LIBDIR  ?= /usr/lib64
-  RBVERSION ?= 2.1.0
+  RBVERSION ?= 2.5.0
   RBDIR      = $(LIBDIR)/ruby/gems/$(RBVERSION)
 endif
 INCDIR    ?= /usr/include

--- a/subst.sh
+++ b/subst.sh
@@ -14,8 +14,8 @@
 # If we ever bump the major version number, more manual work is
 # required.
 #
-VERSION=0.3.8
-DATE="November 2016"
+VERSION=0.3.9
+DATE="July 2020"
 
 # Special case
 if [ $# -eq 1 -a "$1" = "--version" ]; then


### PR DESCRIPTION
Accept `ssh_scp_read` to return less bytes than expected.