### PR TITLE
Some changes to support installing the gem in macOS Big Sur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ all clean install::
 	done
 
 install::
-	mkdir -p $(DESTDIR)/usr/lib/twopence-0
-	cp add_virtio_channel.sh $(DESTDIR)/usr/lib/twopence-0/
+	mkdir -p $(DESTDIR)/usr/local/lib/twopence-0
+	cp add_virtio_channel.sh $(DESTDIR)/usr/local/lib/twopence-0/
 
 tests: server shell
 	make -C tests $@

--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ cat id_rsa.pub >> ~/.ssh/authorized keys
 ```
 
 * repeat for each account that will be used to run the tests
-* in the directory `/usr/lib/twopence/`
+* in the directory `/usr/local/lib/twopence/`
   adapt the first lines of test.rb and test.sh to the IP address or hostname of your system under test
 * run the following commands:
 
 ```console
 $ cd examples
-$ /usr/lib/twopence/test.sh
-$ ruby /usr/lib/twopence/test.rb
+$ /usr/local/lib/twopence/test.sh
+$ ruby /usr/local/lib/twopence/test.rb
 ```
 
 # How do I run the examples with virtio
@@ -116,14 +116,14 @@ $ ruby /usr/lib/twopence/test.rb
 * or you can use the provided script:
 
 ```console
-$ /usr/lib/twopence/add_virtio_channel.sh mydomain
+$ /usr/local/lib/twopence/add_virtio_channel.sh mydomain
 ```
 
 * start the VM
 * copy the test server into the VM:
 
 ```console
-$ scp /usr/lib/twopence/twopence_test_server root@sut.example.com:.
+$ scp /usr/local/lib/twopence/twopence_test_server root@sut.example.com:.
 ```
 
 instead of scp, you may use shared folders or whichever method you prefer
@@ -134,7 +134,7 @@ instead of scp, you may use shared folders or whichever method you prefer
 $ ./twopence_test_server
 ```
 
-* in the directory `/usr/lib/twopence/`
+* in the directory `/usr/local/lib/twopence/`
   adapt the first lines of test.rb and test.sh
   to the name of the socket file you just created; for example:
 
@@ -147,7 +147,7 @@ export TARGET=virtio:/var/run/twopence/test.sock
 ```console
 $ cd examples
 $ export LD_LIBRARY_PATH=../library
-$ ruby /usr/lib/twopence/test.rb
+$ ruby /usr/local/lib/twopence/test.rb
 ```
 
 * if you get error opening the communication,
@@ -166,7 +166,7 @@ $ ls -l /var/run/twopence/test.sock
 * copy the test server into the system under test:
 
 ```console
-$ scp /usr/lib/twopence/twopence_test_server root@sut.example.com:.
+$ scp /usr/local/lib/twopence/twopence_test_server root@sut.example.com:.
 ```
 
 instead of scp, you may use shared folders or whichever method you prefer
@@ -177,7 +177,7 @@ instead of scp, you may use shared folders or whichever method you prefer
 $ ./twopence_test_server
 ```
 
-* in the directory `/usr/lib/twopence/`
+* in the directory `/usr/local/lib/twopence/`
   adapt the first lines of test.rb and test.sh
   to the name of the character device; for example:
 
@@ -189,8 +189,8 @@ export TARGET=serial:/dev/ttyS0
 
 ```console
 $ cd examples
-$ /usr/lib/twopence/test.sh
-$ ruby /usr/lib/twopence/test.rb
+$ /usr/local/lib/twopence/test.sh
+$ ruby /usr/local/lib/twopence/test.rb
 ```
 
 * if you get error opening the communication,

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -3,10 +3,10 @@
 all:
 
 install:
-	mkdir -p $(DESTDIR)/usr/lib/twopence-0
-	cp example.sh $(DESTDIR)/usr/lib/twopence-0
-	cp example.rb $(DESTDIR)/usr/lib/twopence-0
-	cp example.py $(DESTDIR)/usr/lib/twopence-0
+	mkdir -p $(DESTDIR)/usr/local/lib/twopence-0
+	cp example.sh $(DESTDIR)/usr/local/lib/twopence-0
+	cp example.rb $(DESTDIR)/usr/local/lib/twopence-0
+	cp example.py $(DESTDIR)/usr/local/lib/twopence-0
 
 clean:
 

--- a/library/Makefile
+++ b/library/Makefile
@@ -1,11 +1,12 @@
 .PHONY: all install clean
 
-DEBIAN := $(shell cat /etc/os-release | grep 'Debian' >/dev/null && echo "true" || echo "false")
-FEDORA := $(shell cat /etc/os-release | grep 'Fedora' >/dev/null && echo "true" || echo "false")
-SUSE   := $(shell cat /etc/os-release | grep 'SUSE' >/dev/null && echo "true" || echo "false")
-UBUNTU := $(shell cat /etc/os-release | grep 'Ubuntu' >/dev/null && echo "true" || echo "false")
+DEBIAN := $(shell cat /etc/os-release 2>/dev/null | grep 'Debian' >/dev/null && echo "true" || echo "false")
+FEDORA := $(shell cat /etc/os-release 2>/dev/null | grep 'Fedora' >/dev/null && echo "true" || echo "false")
+SUSE   := $(shell cat /etc/os-release 2>/dev/null | grep 'SUSE' >/dev/null && echo "true" || echo "false")
+UBUNTU := $(shell cat /etc/os-release 2>/dev/null | grep 'Ubuntu' >/dev/null && echo "true" || echo "false")
 
 VERSION:= $(shell ../subst.sh --version)
+MACOS  := $(shell sw_vers             2>/dev/null | grep 'macOS' >/dev/null && echo "true" || echo "false")
 
 ifdef RPM_OPT_FLAGS
 CCOPT	= $(RPM_OPT_FLAGS)
@@ -17,10 +18,18 @@ CFLAGS	= -D_GNU_SOURCE -fPIC $(CCOPT)
 
 ifeq ($(UBUNTU),true)
   LIBDIR  ?= /usr/lib/x86_64-linux-gnu
+else ifeq ($(MACOS),true)
+  LIBDIR  ?= /usr/local/lib
 else
   LIBDIR  ?= /usr/lib64
 endif
-INCDIR ?= /usr/include
+
+ifeq ($(MACOS),true)
+	INCDIR ?= /usr/local/include
+else
+	INCDIR ?= /usr/include
+endif
+
 MANDIR ?= /usr/share/man
 
 LIB_OBJS= twopence.o \
@@ -43,6 +52,20 @@ HEADERS	= buffer.h \
 	  twopence.h \
 	  version.h
 
+ifeq ($(MACOS),true)
+all: libtwopence.dylib
+
+libtwopence.dylib: $(HEADERS) $(LIB_OBJS) Makefile
+	$(CC) $(CFLAGS) -dynamiclib -install_name "libtwopence.0.dylib" \
+    -current_version $(VERSION) -o $@ --shared -Wl, $(LIB_OBJS) -lssh -dynamiclib
+
+install:
+	cp -f libtwopence.dylib $(LIBDIR)/libtwopence.0.dylib
+	ln -s $(LIBDIR)/libtwopence.0.dylib $(LIBDIR)/libtwopence.dylib
+	install_name_tool -change "libtwopence.0.dylib" "$(LIBDIR)/libtwopence.0.dylib" $(LIBDIR)/libtwopence.0.dylib
+	mkdir -p $(DESTDIR)$(INCDIR)/twopence
+	install -m444 $(HEADERS) $(DESTDIR)$(INCDIR)/twopence
+else
 all: libtwopence.so
 
 libtwopence.so: $(HEADERS) $(LIB_OBJS) Makefile
@@ -54,10 +77,11 @@ install: libtwopence.so $(HEADERS)
 	mkdir -p $(DESTDIR)$(INCDIR)/twopence
 	install -m444 $(HEADERS) $(DESTDIR)$(INCDIR)/twopence
 	../instman.sh -z -d "$(DESTDIR)" twopence.3
+endif
 
 version.h: version.h.in ../subst.sh
 	../subst.sh < $< > $@
 
 clean:
-	rm -f *.o *.so
+	rm -f *.o *.so *.dylib
 	rm -f version.h

--- a/library/chroot.c
+++ b/library/chroot.c
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <errno.h>
 #include <unistd.h>
 #include <signal.h>
+#include <string.h>
 
 #include "twopence.h"
 #include "pipe.h"

--- a/library/iostream.c
+++ b/library/iostream.c
@@ -20,7 +20,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <sys/stat.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>

--- a/library/ssh.c
+++ b/library/ssh.c
@@ -32,7 +32,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <string.h>
 #include <stdlib.h>
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #include <signal.h>
 #include <assert.h>
 

--- a/library/tcp.c
+++ b/library/tcp.c
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <errno.h>
 #include <unistd.h>
 #include <netdb.h>
+#include <string.h>
 
 #include "twopence.h"
 #include "pipe.h"

--- a/library/transaction.c
+++ b/library/transaction.c
@@ -760,7 +760,7 @@ twopence_transaction_recv_packet(twopence_transaction_t *trans, const twopence_h
 }
 
 
-inline void
+void
 twopence_transaction_send_client(twopence_transaction_t *trans, twopence_buf_t *bp)
 {
 	const twopence_hdr_t *h = (const twopence_hdr_t *) twopence_buf_head(bp);

--- a/library/transaction.h
+++ b/library/transaction.h
@@ -92,7 +92,7 @@ extern unsigned int		twopence_transaction_num_channels(const twopence_transactio
 extern int			twopence_transaction_fill_poll(twopence_transaction_t *trans, twopence_pollinfo_t *);
 extern void			twopence_transaction_doio(twopence_transaction_t *trans);
 extern void			twopence_transaction_recv_packet(twopence_transaction_t *trans, const twopence_hdr_t *hdr, twopence_buf_t *payload);
-extern inline void		twopence_transaction_send_client(twopence_transaction_t *trans, twopence_buf_t *bp);
+extern void	    	twopence_transaction_send_client(twopence_transaction_t *trans, twopence_buf_t *bp);
 extern void			twopence_transaction_send_status(twopence_transaction_t *trans, twopence_status_t *st);
 extern void			twopence_transaction_fail(twopence_transaction_t *, int);
 extern void			twopence_transaction_fail2(twopence_transaction_t *trans, int major, int minor);

--- a/library/twopence.c
+++ b/library/twopence.c
@@ -19,7 +19,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>

--- a/library/utils.h
+++ b/library/utils.h
@@ -23,6 +23,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <sys/types.h>
 #include <stdbool.h>
 #include <poll.h>
+#include <signal.h>
+#include <limits.h>
 
 typedef struct twopence_timeout {
 	struct timeval		now;
@@ -39,6 +41,10 @@ typedef struct twopence_pollinfo {
 typedef struct twopence_timer_list {
 	struct twopence_timer *		head;
 } twopence_timer_list_t;
+
+#ifndef HAVE_PPOLL
+extern int      ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *ts, const sigset_t *sigmask);
+#endif
 
 extern void		twopence_timeout_init(twopence_timeout_t *);
 extern bool		twopence_timeout_update(twopence_timeout_t *, const struct timeval *deadline);

--- a/library/virtio.c
+++ b/library/virtio.c
@@ -27,6 +27,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <poll.h>
 #include <errno.h>
 #include <unistd.h>
+#include <string.h>
 
 #include "twopence.h"
 #include "pipe.h"

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,8 +1,9 @@
 
-DEBIAN := $(shell cat /etc/os-release | grep 'Debian' >/dev/null && echo "true" || echo "false")
-FEDORA := $(shell cat /etc/os-release | grep 'Fedora' >/dev/null && echo "true" || echo "false")
-SUSE   := $(shell cat /etc/os-release | grep 'SUSE' >/dev/null && echo "true" || echo "false")
-UBUNTU := $(shell cat /etc/os-release | grep 'Ubuntu' >/dev/null && echo "true" || echo "false")
+DEBIAN := $(shell cat /etc/os-release 2>/dev/null | grep 'Debian' >/dev/null && echo "true" || echo "false")
+FEDORA := $(shell cat /etc/os-release 2>/dev/null | grep 'Fedora' >/dev/null && echo "true" || echo "false")
+SUSE   := $(shell cat /etc/os-release 2>/dev/null | grep 'SUSE' >/dev/null && echo "true" || echo "false")
+UBUNTU := $(shell cat /etc/os-release 2>/dev/null | grep 'Ubuntu' >/dev/null && echo "true" || echo "false")
+MACOS  := $(shell sw_vers             2>/dev/null | grep 'macOS' >/dev/null && echo "true" || echo "false")
 
 ifdef RPM_OPT_FLAGS
 CCOPT	= $(RPM_OPT_FLAGS)
@@ -13,23 +14,47 @@ endif
 CFLAGS	= -fPIC -I/usr/include/python -I/usr/include/python2.7 
 CFLAGS  += -I../library $(CCOPT)
 
-LIBDIR ?= /usr/lib64
+ifeq ($(MACOS),true)
+	CFLAGS+= -undefined dynamic_lookup
+endif
+
+ifeq ($(MACOS),true)
+	LIBDIR ?= /usr/local/lib
+else
+	LIBDIR ?= /usr/lib64
+endif
+
 ifeq ($(FEDORA),true)
     PYDIR := $(LIBDIR)/python2.7/site-packages/
 else ifeq ($(UBUNTU),true)
     PYDIR := $(LIBDIR)/python2.7/site-packages/
+else ifeq ($(MACOS),true)
+	PYDIR := $(LIBDIR)/python2.7/site-packages/
 else
     PYDIR := $(shell readlink -f $(LIBDIR)/python/site-packages)
 endif
 
-OBJS	= extension.o \
-	  command.o \
-	  transfer.o \
-	  status.o \
-	  chat.o \
-	  timer.o \
-	  target.o
+OBJS = extension.o \
+	   command.o \
+	   transfer.o \
+	   status.o \
+	   chat.o \
+	   timer.o \
+	   target.o
 
+ifeq ($(MACOS),true)
+all: twopence.dylib
+
+twopence.dylib: $(OBJS)
+	$(CC) $(CFLAGS) -dynamiclib -install_name "twopence.0.dylib" -o $@ --shared -Wl, $(OBJS) -L../library -ltwopence
+
+clean:
+	rm -f *.o *.dylib
+
+install:
+	mkdir -p $(DESTDIR)$(PYDIR)
+	cp twopence.dylib $(DESTDIR)$(PYDIR)
+else
 all: twopence.so
 
 twopence.so: $(OBJS)
@@ -42,3 +67,4 @@ install:
 	mkdir -p $(DESTDIR)$(PYDIR)
 	cp twopence.so $(DESTDIR)$(PYDIR)
 	../instman.sh -z -d "$(DESTDIR)" twopence.3py
+endif

--- a/python/extension.h
+++ b/python/extension.h
@@ -21,8 +21,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef TWOPENCE_PYTHON_EXT_H
 #define TWOPENCE_PYTHON_EXT_H
 
-
+#ifdef __APPLE__
+#include <Python/Python.h>
+#else
 #include <Python.h>
+#endif
 #include <twopence.h>
 #include <string.h>
 #include "utils.h"

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -1,21 +1,32 @@
 .PHONY: all install clean
 
-DEBIAN := $(shell cat /etc/os-release | grep 'Debian' >/dev/null && echo "true" || echo "false")
-FEDORA := $(shell cat /etc/os-release | grep 'Fedora' >/dev/null && echo "true" || echo "false")
-SUSE   := $(shell cat /etc/os-release | grep 'SUSE' >/dev/null && echo "true" || echo "false")
-UBUNTU := $(shell cat /etc/os-release | grep 'Ubuntu' >/dev/null && echo "true" || echo "false")
+DEBIAN := $(shell cat /etc/os-release 2>/dev/null | grep 'Debian' >/dev/null && echo "true" || echo "false")
+FEDORA := $(shell cat /etc/os-release 2>/dev/null | grep 'Fedora' >/dev/null && echo "true" || echo "false")
+SUSE   := $(shell cat /etc/os-release 2>/dev/null | grep 'SUSE' >/dev/null && echo "true" || echo "false")
+UBUNTU := $(shell cat /etc/os-release 2>/dev/null | grep 'Ubuntu' >/dev/null && echo "true" || echo "false")
+MACOS  := $(shell sw_vers             2>/dev/null | grep 'macOS' >/dev/null && echo "true" || echo "false")
 
 ARCH      ?= x86_64
 ifeq ($(UBUNTU),true)
   LIBDIR  ?= /usr/lib/x86_64-linux-gnu
   RBVERSION ?= 2.3.0
   RBDIR      = $(LIBDIR)/ruby/$(RBVERSION)
+else ifeq ($(MACOS),true)
+  LIBDIR  ?= /usr/local/lib
+  RBVERSION ?= 2.7.0
+  RBDIR      = $(LIBDIR)/ruby/gems/$(RBVERSION)
 else
   LIBDIR  ?= /usr/lib64
   RBVERSION ?= 2.5.0
   RBDIR      = $(LIBDIR)/ruby/gems/$(RBVERSION)
 endif
-INCDIR    ?= /usr/include
+
+ifeq ($(MACOS),true)
+	INCDIR    ?= /usr/local/include
+else
+	INCDIR    ?= /usr/include
+endif
+
 VERSION   := $(shell ../subst.sh --version)
 
 all: twopence-$(VERSION).gem
@@ -28,8 +39,13 @@ twopence-$(VERSION).gem: twopence.gemspec Rakefile ext/twopence/extconf.rb \
 twopence.gemspec: twopence.gemspec.in ../subst.sh
 	../subst.sh < $< > $@
 
+ifeq ($(MACOS),true)
+install: twopence-$(VERSION).gem
+	ln -sf $(DESTDIR)$(LIBDIR)/libtwopence.0.dylib $(DESTDIR)$(LIBDIR)/libtwopence.dylib
+else
 install: twopence-$(VERSION).gem
 	ln -sf $(DESTDIR)$(LIBDIR)/libtwopence.so.$(VERSION) $(DESTDIR)$(LIBDIR)/libtwopence.so
+endif
 
 ifeq ($(UBUNTU),true)
 	CFLAGS="-I$(DESTDIR)$(INCDIR)" LDFLAGS="-L$(DESTDIR)$(LIBDIR)" DESTDIR="" \
@@ -41,14 +57,18 @@ else ifeq ($(FEDORA),true)
                gem install --local \
                      --install-dir "$(RBDIR)/" \
                      -V --force twopence-$(VERSION).gem
+else ifeq ($(MACOS),true)
+	CFLAGS="-I$(DESTDIR)$(INCDIR)" LDFLAGS="-L$(DESTDIR)$(LIBDIR)" DESTDIR="" \
+	       gem install --local \
+                     --build-root "$(DESTDIR)/" \
+                     --install-dir "$(RBDIR)/" \
+                     -V --force twopence-$(VERSION).gem
 else
 	CFLAGS="-I$(DESTDIR)$(INCDIR)" LDFLAGS="-L$(DESTDIR)$(LIBDIR)" DESTDIR="" \
 	       gem install --local \
                      --build-root "$(DESTDIR)/" \
                      --install-dir "$(RBDIR)/" \
                      -V --force twopence-$(VERSION).gem
-	rm $(DESTDIR)$(LIBDIR)/libtwopence.so
-	rm -f $(DESTDIR)$(RBDIR)/gems/twopence-$(VERSION)/ext/twopence/siteconf*.rb
 endif
 
 clean:
@@ -56,4 +76,4 @@ clean:
 	rm -f ext/library/buffer.h
 	rm -f ruby/ext/twopence/Makefile
 	rm -f ruby/ext/twopence/mkmf.log
-	rm -f twopence-$(VERSION).gem
+	rm -f twopence-*.gem

--- a/ruby/ext/twopence/extconf.rb
+++ b/ruby/ext/twopence/extconf.rb
@@ -3,7 +3,7 @@ require 'mkmf'
 extension_name = 'twopence'
 dir_config(extension_name)
 
-$LDFLAGS = ENV['LDFLAGS'] + ' ' + $LDFLAGS
-$CFLAGS = ENV['CFLAGS'] + ' ' + $CFLAGS
+$LDFLAGS = "#{ENV['LDFLAGS']} #{$LDFLAGS}"
+$CFLAGS = "#{ENV['CFLAGS']} #{$CFLAGS}"
 have_library('twopence', 'twopence_target_new') or raise
 create_makefile(extension_name)

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,12 +1,14 @@
 .PHONY: all install clean
 
+MACOS  := $(shell sw_vers             2>/dev/null | grep 'macOS' >/dev/null && echo "true" || echo "false")
+
 ifdef RPM_OPT_FLAGS
 CCOPT	= $(RPM_OPT_FLAGS)
 else
 CCOPT	= -Wall -O2 -g
 endif
 
-BINDIR ?= /usr/bin
+BINDIR ?= /usr/local/bin
 
 SERVER	= twopence_test_server
 OBJS	= main.o \
@@ -23,7 +25,9 @@ $(SERVER): $(OBJS)
 install: $(SERVER)
 	mkdir -p $(DESTDIR)$(BINDIR)
 	install -m555 $(SERVER) $(DESTDIR)$(BINDIR)
+ifeq ($(MACOS),false)
 	../instman.sh -z -d "$(DESTDIR)" -n twopence_test_server.1 server.1
+endif
 
 clean:
 	rm -f $(SERVER) *.o

--- a/shell/Makefile
+++ b/shell/Makefile
@@ -1,5 +1,7 @@
 .PHONY: all install clean
 
+MACOS  := $(shell sw_vers             2>/dev/null | grep 'macOS' >/dev/null && echo "true" || echo "false")
+
 ifdef RPM_OPT_FLAGS
 CCOPT	= $(RPM_OPT_FLAGS)
 else
@@ -9,7 +11,7 @@ endif
 CFLAGS	= -I../library $(CCOPT)
 LINK	+= -L../library -ltwopence
 
-BINDIR ?= /usr/bin
+BINDIR ?= /usr/local/bin
 MANDIR ?= /usr/share/man
 
 all: command inject extract exit
@@ -32,7 +34,9 @@ install: command inject extract exit command.1 inject.1 extract.1 exit.1
 	cp inject $(DESTDIR)$(BINDIR)/twopence_inject
 	cp extract $(DESTDIR)$(BINDIR)/twopence_extract
 	cp exit $(DESTDIR)$(BINDIR)/twopence_exit
+ifeq ($(MACOS),false)
 	../instman.sh -z -d "$(DESTDIR)" -p twopence_ *.1
+endif
 
 clean:
 	rm -f command

--- a/subst.sh
+++ b/subst.sh
@@ -14,8 +14,8 @@
 # If we ever bump the major version number, more manual work is
 # required.
 #
-VERSION=0.3.9
-DATE="July 2020"
+VERSION=0.4.0
+DATE="December 2020"
 
 # Special case
 if [ $# -eq 1 -a "$1" = "--version" ]; then


### PR DESCRIPTION
Hi guys,

I was tired of not being able to run my tests in my Macbook, my test framework is using the gem of twopence as a dependency.

I succeed installing the gem not without some changes in this code:
```
oscar@Oscar twopence % gem info twopence

*** LOCAL GEMS ***

twopence (0.3.10)
    Author: SUSE
    Homepage: http://www.suse.com
    License: GPL-2.0
    Installed at: /usr/local/lib/ruby/gems/2.7.0

    Twopence test executor
```

Please, could you take a look?
Even if working here, I'm sure it could be plenty of mistakes and things to code it better... 