### PR TITLE
Version 0.4.1: fix build issues on SLES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,18 @@
         library-install server-install ruby-install shell-install examples-install \
         library-clean server-clean ruby-clean shell-clean examples-clean
 
+DEBIAN := $(shell cat /etc/os-release 2>/dev/null | grep 'Debian' >/dev/null && echo "true" || echo "false")
+FEDORA := $(shell cat /etc/os-release 2>/dev/null | grep 'Fedora' >/dev/null && echo "true" || echo "false")
+SUSE   := $(shell cat /etc/os-release 2>/dev/null | grep 'SUSE' >/dev/null && echo "true" || echo "false")
+UBUNTU := $(shell cat /etc/os-release 2>/dev/null | grep 'Ubuntu' >/dev/null && echo "true" || echo "false")
+MACOS  := $(shell sw_vers             2>/dev/null | grep 'macOS' >/dev/null && echo "true" || echo "false")
+
+ifeq ($(MACOS),true)
+  TWOPENCE_DIR = /usr/local/lib/twopence-0
+else
+  TWOPENCE_DIR = /usr/lib/twopence-0
+endif
+
 SUBDIRS = \
 	library \
 	server \
@@ -18,8 +30,8 @@ all clean install::
 	done
 
 install::
-	mkdir -p $(DESTDIR)/usr/local/lib/twopence-0
-	cp add_virtio_channel.sh $(DESTDIR)/usr/local/lib/twopence-0/
+	mkdir -p $(DESTDIR)/$(TWOPENCE_DIR)
+	cp add_virtio_channel.sh $(DESTDIR)/$(TWOPENCE_DIR)/
 
 tests: server shell
 	make -C tests $@

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,12 +1,24 @@
 .PHONY: all install clean
 
+DEBIAN := $(shell cat /etc/os-release 2>/dev/null | grep 'Debian' >/dev/null && echo "true" || echo "false")
+FEDORA := $(shell cat /etc/os-release 2>/dev/null | grep 'Fedora' >/dev/null && echo "true" || echo "false")
+SUSE   := $(shell cat /etc/os-release 2>/dev/null | grep 'SUSE' >/dev/null && echo "true" || echo "false")
+UBUNTU := $(shell cat /etc/os-release 2>/dev/null | grep 'Ubuntu' >/dev/null && echo "true" || echo "false")
+MACOS  := $(shell sw_vers             2>/dev/null | grep 'macOS' >/dev/null && echo "true" || echo "false")
+
+ifeq ($(MACOS),true)
+  TWOPENCE_DIR = /usr/local/lib/twopence-0
+else
+  TWOPENCE_DIR = /usr/lib/twopence-0
+endif
+
 all:
 
 install:
-	mkdir -p $(DESTDIR)/usr/local/lib/twopence-0
-	cp example.sh $(DESTDIR)/usr/local/lib/twopence-0
-	cp example.rb $(DESTDIR)/usr/local/lib/twopence-0
-	cp example.py $(DESTDIR)/usr/local/lib/twopence-0
+	mkdir -p $(DESTDIR)/$(TWOPENCE_DIR)
+	cp example.sh $(DESTDIR)/$(TWOPENCE_DIR)/
+	cp example.rb $(DESTDIR)/$(TWOPENCE_DIR)/
+	cp example.py $(DESTDIR)/$(TWOPENCE_DIR)/
 
 clean:
 

--- a/subst.sh
+++ b/subst.sh
@@ -14,8 +14,8 @@
 # If we ever bump the major version number, more manual work is
 # required.
 #
-VERSION=0.4.0
-DATE="December 2020"
+VERSION=0.4.1
+DATE="August 2021"
 
 # Special case
 if [ $# -eq 1 -a "$1" = "--version" ]; then


### PR DESCRIPTION
This version fixes problems for building twopence on SLES

(path issues induced by adaptations to Mac OS Big Sur)