### PR TITLE
Version 0.4.2: allow to specify buffer size

### DIFF
--- a/shell/command.1
+++ b/shell/command.1
@@ -69,6 +69,10 @@ Options \fB\-o\fR, \fB\-1\fR/\fB\-2\fR, and \fBq\fR are mutually exclusive.
 Store the results separately, stdout going to the first file, and
 stderr going to the second file.
 Options \fB\-o\fR, \fB\-1\fR/\fB\-2\fR, and \fBq\fR are mutually exclusive.
+.IP \fB\-s\fR\ \fISIZE\fR
+.IP \fB\-\-size\fR\ \fISIZE\fR
+Defines the size of the output buffers (both joint buffer and
+separate stdout and stderr). Defaults to 65536 bytes.
 .IP \fB\-q\fR
 .IP \fB\-\-quiet\fR
 Do not output stdout nor stderr.

--- a/subst.sh
+++ b/subst.sh
@@ -14,7 +14,7 @@
 # If we ever bump the major version number, more manual work is
 # required.
 #
-VERSION=0.4.1
+VERSION=0.4.2
 DATE="August 2021"
 
 # Special case


### PR DESCRIPTION
This PR allows to change the size of the output buffers.

Only ruby and shell for now: python code is really too convoluted.

Fixes SUSE/spacewalk#15566
