### PR TITLE
Fix building on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ apt-get install gcc libssh-dev ruby-dev rake-compiler python-dev
 
 # Fedora
 dnf install gcc libssh-devel ruby-devel rubygem-rake-compiler python-devel redhat-rpm-config
+
+# MacOS
+xcode-select --install
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install libssh
+sudo ln -s /opt/homebrew/Cellar/libssh/<your_version>/include/libssh /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libssh
+brew install pyenv
+pyenv install 2.7
+ln -s $HOME/.pyenv/versions/2.7.18/include/python2.7 $HOME/.pyenv/versions/2.7.18/include/Python
 ```
 
 ### Build and installation

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ apt-get install gcc libssh-dev ruby-dev rake-compiler python-dev
 dnf install gcc libssh-devel ruby-devel rubygem-rake-compiler python-devel redhat-rpm-config
 
 # MacOS
+# install the Xcode command line tools
 xcode-select --install
+# Install Homebrew (https://brew.sh)
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew install libssh
 sudo ln -s /opt/homebrew/Cellar/libssh/<your_version>/include/libssh /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libssh

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ apt-get install gcc libssh-dev ruby-dev rake-compiler python-dev
 # Fedora
 dnf install gcc libssh-devel ruby-devel rubygem-rake-compiler python-devel redhat-rpm-config
 
-# MacOS
+# macOS (tested on Sonoma)
 # install the Xcode command line tools
 xcode-select --install
 # Install Homebrew (https://brew.sh)

--- a/library/Makefile
+++ b/library/Makefile
@@ -26,6 +26,7 @@ endif
 
 ifeq ($(MACOS),true)
 	INCDIR ?= /usr/local/include
+	CFLAGS	= -D_GNU_SOURCE -fPIC $(CCOPT) -I /opt/homebrew/include -I ext -L /opt/homebrew/lib -lssh 
 else
 	INCDIR ?= /usr/include
 endif

--- a/python/Makefile
+++ b/python/Makefile
@@ -15,21 +15,18 @@ CFLAGS	= -fPIC -I/usr/include/python -I/usr/include/python2.7
 CFLAGS  += -I../library $(CCOPT)
 
 ifeq ($(MACOS),true)
-	CFLAGS+= -undefined dynamic_lookup
+	CFLAGS	= -fPIC -I$(HOME)/.pyenv/versions/2.7.18/include -I$(HOME)/.pyenv/versions/2.7.18/include/python2.7
+    CFLAGS  += -I../library $(CCOPT) -undefined dynamic_lookup
 endif
 
-ifeq ($(MACOS),true)
-	LIBDIR ?= /usr/local/lib
-else
-	LIBDIR ?= /usr/lib64
-endif
+LIBDIR ?= /usr/lib64
 
 ifeq ($(FEDORA),true)
     PYDIR := $(LIBDIR)/python2.7/site-packages/
 else ifeq ($(UBUNTU),true)
     PYDIR := $(LIBDIR)/python2.7/site-packages/
 else ifeq ($(MACOS),true)
-	PYDIR := $(LIBDIR)/python2.7/site-packages/
+	PYDIR := $(HOME)/.pyenv/versions/2.7.18/lib/python2.7/site-packages
 else
     PYDIR := $(shell readlink -f $(LIBDIR)/python/site-packages)
 endif

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -58,7 +58,7 @@ else ifeq ($(FEDORA),true)
                      --install-dir "$(RBDIR)/" \
                      -V --force twopence-$(VERSION).gem
 else ifeq ($(MACOS),true)
-	CFLAGS="-I$(DESTDIR)$(INCDIR)" LDFLAGS="-L$(DESTDIR)$(LIBDIR)" DESTDIR="" \
+	CFLAGS="-I /opt/homebrew/include -I ext -L /opt/homebrew/lib -lssh -I$(DESTDIR)$(INCDIR)" LDFLAGS="-L$(DESTDIR)$(LIBDIR)" DESTDIR="" \
 	       gem install --local \
                      --build-root "$(DESTDIR)/" \
                      --install-dir "$(RBDIR)/" \


### PR DESCRIPTION
This PR fix the issues I'm having building Twopence on my MacOS Ventura.

- It describes the necessary previous steps in the documentation
- Add paths of Homebrew to access libssh library
- Add paths of PyEnv to access Python 2.7 (as by default xCode install 3.9)