### PR TITLE
Simplify virsh call

### DIFF
--- a/add_virtio_channel.sh
+++ b/add_virtio_channel.sh
@@ -4,7 +4,7 @@
 # Usage: ./add_virtio_channel domain 
 
 virsh="virsh -c qemu:///system"
-list=$($virsh list --all | tail -n +3 | tr -s ' ' | cut -f 3 -d ' ')
+list=$($virsh list --all --name)
 
 function usage
 {


### PR DESCRIPTION
Substitute shell voodoo with native output formatting.

```
$ virsh list --all | tail -n +3 | tr -s ' ' | cut -f 3 -d ' '
Leap01
Leap01_BIOS
Tumbleweed01
Tumblweed01_BIOS

```
vs

```
$ virsh list --all --name
Leap01
Leap01_BIOS
Tumbleweed01
Tumblweed01_BIOS

```
