### PR TITLE
Switch /var/run to /run

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ instead of scp, you may use shared folders or whichever method you prefer
   to the name of the socket file you just created; for example:
 
 ```bash
-export TARGET=virtio:/var/run/twopence/test.sock
+export TARGET=virtio:/run/twopence/test.sock
 ```
 
 * run the following commands:
@@ -151,7 +151,7 @@ ruby /usr/local/lib/twopence/test.rb
   check the permissions of the socket file:
 
 ```bash
-ls -l /var/run/twopence/test.sock
+ls -l /run/twopence/test.sock
 ```
 
 ## How do I run the examples with a serial cable

--- a/add_virtio_channel.sh
+++ b/add_virtio_channel.sh
@@ -24,7 +24,7 @@ domain="$1"
 
 function add_port
 {
-  socket=/var/run/twopence/${domain}.sock
+  socket=/run/twopence/${domain}.sock
   name=org.opensuse.twopence.0
   grep -q "<target type='virtio' name='${name}'/>" $tmpfile
   if [ $? -eq 0 ]; then

--- a/examples/example.py
+++ b/examples/example.py
@@ -6,7 +6,7 @@ import os
 try:
   #######################################################################
   # Adapt the following line to your setup
-  #   target = twopence::Target("virtio:/var/run/twopence/test.sock")
+  #   target = twopence::Target("virtio:/run/twopence/test.sock")
   #   target = twopence::Target("ssh:192.168.123.45")
   #   target = twopence::Target("serial:/dev/ttyS0")
   target = twopence.Target( YOUR_TARGET_HERE )

--- a/examples/example.rb
+++ b/examples/example.rb
@@ -6,7 +6,7 @@ require "fileutils"
 begin
 #######################################################################
 # Adapt the following line to your setup
-#   $target = Twopence::init("virtio:/var/run/twopence/test.sock")
+#   $target = Twopence::init("virtio:/run/twopence/test.sock")
 #   $target = Twopence::init("ssh:192.168.123.45")
 #   $target = Twopence::init("serial:/dev/ttyS0")
 $target = Twopence::init( YOUR_TARGET_HERE )

--- a/examples/example.sh
+++ b/examples/example.sh
@@ -2,7 +2,7 @@
 
 ##########################################################
 # Adapt the following line to your setup
-#   export TARGET=virtio:/var/run/twopence/test.sock
+#   export TARGET=virtio:/run/twopence/test.sock
 #   export TARGET=ssh:192.168.123.45
 #   export TARGET=serial:/dev/ttyS0
 export TARGET= YOUR_TARGET_HERE

--- a/python/twopence.3py
+++ b/python/twopence.3py
@@ -63,7 +63,7 @@ This is the name assigned to it by the constructor.
 .TP
 .BR type " (read-only)
 This is the target type, which is the leading portion of the string passed into the
-constructor. For example, if you created a target for \(dqvirtio:/var/run/foo.socket\(dq, then
+constructor. For example, if you created a target for \(dqvirtio:/run/foo.socket\(dq, then
 the this attribute will contain \(dqvirtio\(dq.
 .\" --------------------------------------------------------------
 .\"

--- a/server/main.c
+++ b/server/main.c
@@ -49,7 +49,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "version.h"
 
 #define TWOPENCE_SERIAL_PORT_DEFAULT	"/dev/virtio-ports/org.opensuse.twopence.0"
-#define TWOPENCE_UNIX_PORT_DEFAULT	"/var/run/twopence.sock"
+#define TWOPENCE_UNIX_PORT_DEFAULT	"/run/twopence.sock"
 #define TWOPENCE_TCP_PORT_DEFAULT	64123
 
 #define TWOPENCE_SERVER_PARAMETER_ERROR -1

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -3,7 +3,7 @@
 # Test script to exercise the Python wrapper.
 #
 # Provide a target on the command line using
-#   python_test.py virtio:/var/run/twopence/test.sock
+#   python_test.py virtio:/run/twopence/test.sock
 #   python_test.py ssh:192.168.123.45
 #   python_test.py serial:/dev/ttyS0
 ##########################################################

--- a/tests/ruby_test.sh
+++ b/tests/ruby_test.sh
@@ -3,7 +3,7 @@
 # Test script to exercise the Ruby wrapper.
 #
 # Provide a target on the command line using
-#   ruby_test.sh virtio:/var/run/twopence/test.sock
+#   ruby_test.sh virtio:/run/twopence/test.sock
 #   ruby_test.sh ssh:192.168.123.45
 #   ruby_test.sh serial:/dev/ttyS0
 ##########################################################

--- a/tests/shell_test.sh
+++ b/tests/shell_test.sh
@@ -3,7 +3,7 @@
 # Test script to exercise the shell commands.
 #
 # Provide a target on the command line using
-#   shell_test.sh virtio:/var/run/twopence/test.sock
+#   shell_test.sh virtio:/run/twopence/test.sock
 #   shell_test.sh ssh:192.168.123.45
 #   shell_test.sh serial:/dev/ttyS0
 ##########################################################


### PR DESCRIPTION
- /var/run is deprecated: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s13.html
- the package already uses /run: https://build.opensuse.org/package/view_file/devel:tools/twopence/twopence-tmpfiles.conf