### PR TITLE
Use Ruby 3.3 for non Ubuntu/macOS

### DIFF
--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -17,7 +17,7 @@ else ifeq ($(MACOS),true)
   RBDIR      = $(LIBDIR)/ruby/gems/$(RBVERSION)
 else
   LIBDIR  ?= /usr/lib64
-  RBVERSION ?= 2.5.0
+  RBVERSION ?= 3.3.0
   RBDIR      = $(LIBDIR)/ruby/gems/$(RBVERSION)
 endif
 

--- a/ruby/ext/twopence/glue.c
+++ b/ruby/ext/twopence/glue.c
@@ -46,4 +46,5 @@ void Init_twopence()
   rb_define_method(ruby_target_class, "extract_file", method_extract_file, -2);
   rb_define_method(ruby_target_class, "interrupt_command", method_interrupt_command, 0);
   rb_define_method(ruby_target_class, "exit", method_exit, 0);
+  rb_undef_alloc_func(ruby_target_class);
 }


### PR DESCRIPTION
# Description

Change default Ruby version to 3.3 for non-Ubuntu and macOS operating systems.

# TODO

- [x] Take care of
```bash
dominik-ctl:~/spacewalk/testsuite # cucumber features/init_clients/proxy_container.feature
DEBUG MODE ENABLED.
Capybara APP Host: https://dominik-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
/root/spacewalk/testsuite/features/support/twopence_init.rb:76: warning: undefining the allocator of T_DATA class Twopence::Target
Host 'server' is alive with determined hostname dominik-srv and FQDN dominik-srv.mgr.suse.de
```

This warning indicates that our Ruby C extension is defining a class `Twopence::Target` as a `T_DATA` object (which is correct for wrapping C structs), but it's not explicitly defining an allocator for this class. This can lead to unexpected behavior and potential issues.

There are 2 solutions:

1.
```c
void Init_twopence()
{
  // Ruby initializations
  VALUE ruby_target_class;
  Twopence = rb_define_module("Twopence");
  rb_define_singleton_method(Twopence, "init", method_init, 1);
  ruby_target_class = rb_define_class_under(Twopence, "Target", rb_cObject);
  rb_define_method(ruby_target_class, "test_and_print_results", method_test_and_print_results, -2);
  rb_define_method(ruby_target_class, "test_and_drop_results", method_test_and_drop_results, -2);
  rb_define_method(ruby_target_class, "test_and_store_results_separately", method_test_and_store_results_separately, -2);
  rb_define_method(ruby_target_class, "test_and_store_results_together", method_test_and_store_results_together, -2);
  rb_define_method(ruby_target_class, "inject_file", method_inject_file, -2);
  rb_define_method(ruby_target_class, "extract_file", method_extract_file, -2);
  rb_define_method(ruby_target_class, "interrupt_command", method_interrupt_command, 0);
  rb_define_method(ruby_target_class, "exit", method_exit, 0);
  rb_undef_alloc_func(ruby_target_class);  // <---- new
}
```

2. Defining and using our own allocator
```c
VALUE alloc_target(VALUE)

VALUE alloc_target(VALUE klass)
{
  struct twopence_target *target;

  target = ALLOC(struct twopence_target);
  if (!target) rb_raise(rb_eNoMemError, "allocation failure");
  return Data_Wrap_Struct(klass, NULL, deallocate_target, target);
}
```

# Links

- https://github.com/SUSE/spacewalk/issues/17431
- https://bugs.ruby-lang.org/issues/18007
- https://docs.ruby-lang.org/en/master/extension_rdoc.html#label-C+struct+to+Ruby+object